### PR TITLE
Implement stateful Jira mock server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.env
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Mock Jira Cloud Server
+
+This repository implements a stateful mock server that emulates the most used
+surfaces of the Jira Cloud REST APIs. It is meant for integration testing and
+local development where hitting the real Atlassian endpoints is impractical.
+
+## Features
+
+- **Jira Platform REST API v3**: Issues, search, transitions, comments,
+  projects, fields, users and webhook registration.
+- **Jira Software (Agile) API**: Boards, sprints and backlog listings with
+  pagination support.
+- **Jira Service Management API**: Portal request CRUD with simple approvals.
+- **ADF aware payloads**: descriptions and comments are stored and returned as
+  Atlassian Document Format documents.
+- **Webhooks**: Register mock webhook listeners and inspect all deliveries via a
+  helper endpoint.
+- **Auth + rate limiting**: Bearer token authentication using seeded API tokens
+  and a light cost counter with optional `X-Force-429` simulation header.
+
+The in-memory store ships with a realistic data seed (projects `DEV` and `SUP`,
+multiple users, boards and sprints). All write operations update this state so
+responses stay consistent across calls.
+
+## Getting started
+
+```bash
+python -m pip install -e .[test]
+mock-jira-server --port 9000
+```
+
+The server exposes FastAPI docs at `http://localhost:9000/docs`.
+
+Authenticated requests must include `Authorization: Bearer mock-token` unless
+you customise the store.
+
+### Useful endpoints
+
+- `GET /rest/api/3/project` — list seeded projects.
+- `POST /rest/api/3/issue` — create an issue. Responses include JQL-searchable
+  data and webhook deliveries are recorded.
+- `GET /rest/api/3/_mock/webhooks/deliveries` — retrieve all webhook payloads
+  emitted during the session.
+- `GET /rest/agile/1.0/board` — agile boards with pagination metadata.
+- `POST /rest/servicedeskapi/request` — create a service request based on the
+  seeded Support project.
+
+### Running the test suite
+
+```bash
+python -m pip install -e .[test]
+pytest
+```
+
+## Extending
+
+- Update `mockjira/store.py` to add new seed data or stateful behaviours.
+- Add new routers under `mockjira/routers/` for further API families (e.g. JQL
+  API group or additional webhook utilities).
+- Integrate real OpenAPI documents via tooling such as Stoplight Prism if you
+  prefer contract-first mocking; this project focuses on a higher-level,
+  stateful emulation.
+
+## License
+
+MIT

--- a/mockjira/__init__.py
+++ b/mockjira/__init__.py
@@ -1,0 +1,3 @@
+"""Mock Jira server package."""
+
+from .app import create_app  # noqa: F401

--- a/mockjira/app.py
+++ b/mockjira/app.py
@@ -1,0 +1,40 @@
+"""Application factory for the mock Jira server."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .auth import auth_dependency, get_current_user
+from .routers import agile, platform, service_management, webhooks
+from .store import InMemoryStore
+
+
+def create_app(store: InMemoryStore | None = None) -> FastAPI:
+    """Create a FastAPI instance configured with all routes.
+
+    Parameters
+    ----------
+    store:
+        Optional :class:`InMemoryStore` instance. When ``None`` a new store with
+        seeded data is created. Passing a custom store is useful for testing.
+    """
+
+    store = store or InMemoryStore.with_seed_data()
+
+    app = FastAPI(
+        title="Mock Jira Cloud",
+        version="0.1.0",
+        description=(
+            "Stateful mock implementation of popular Jira Cloud API surfaces."
+        ),
+    )
+
+    app.dependency_overrides[get_current_user] = auth_dependency(store)
+    app.include_router(platform.router, prefix="/rest/api/3")
+    app.include_router(agile.router, prefix="/rest/agile/1.0")
+    app.include_router(service_management.router, prefix="/rest/servicedeskapi")
+    app.include_router(webhooks.router, prefix="/rest/api/3")
+
+    app.state.store = store
+
+    return app

--- a/mockjira/auth.py
+++ b/mockjira/auth.py
@@ -1,0 +1,55 @@
+"""Authentication and rate limiting helpers."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import Header, HTTPException, status
+
+from .store import InMemoryStore, RateLimitError
+
+
+async def get_current_user(  # pragma: no cover - replaced during app setup
+    authorization: str | None = Header(default=None),
+    x_force_429: str | None = Header(default=None),
+) -> str:
+    raise RuntimeError("Authentication dependency not configured")
+
+
+def auth_dependency(store: InMemoryStore) -> Callable:
+    """Return a dependency enforcing bearer token auth and rate limiting."""
+
+    async def dependency(
+        authorization: str | None = Header(default=None),
+        x_force_429: str | None = Header(default=None),
+    ) -> str:
+        if authorization is None or not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing bearer token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        token = authorization.split(" ", 1)[1]
+        if not store.is_valid_token(token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid API token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if x_force_429:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Simulated rate limit",
+                headers={"Retry-After": "5"},
+            )
+        try:
+            store.register_call(token)
+        except RateLimitError as exc:  # pragma: no cover - protective branch
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Rate limit exceeded",
+                headers={"Retry-After": str(exc.retry_after)},
+            ) from exc
+        return store.tokens[token]
+
+    return dependency

--- a/mockjira/main.py
+++ b/mockjira/main.py
@@ -1,0 +1,47 @@
+"""CLI entrypoint for running the mock Jira server."""
+
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+from .app import create_app
+from .store import InMemoryStore
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Mock Jira Cloud server")
+    parser.add_argument(
+        "--host", default="0.0.0.0", help="Host interface to bind the server"
+    )
+    parser.add_argument(
+        "--port", type=int, default=8000, help="TCP port to bind the server"
+    )
+    parser.add_argument(
+        "--log-level", default="info", help="Log level passed to Uvicorn"
+    )
+    parser.add_argument(
+        "--no-seed",
+        action="store_true",
+        help="Start with an empty store instead of the default seed data",
+    )
+    return parser
+
+
+def run(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    store = None if args.no_seed else InMemoryStore.with_seed_data()
+    app = create_app(store)
+
+    config = uvicorn.Config(
+        app, host=args.host, port=args.port, log_level=args.log_level
+    )
+    server = uvicorn.Server(config)
+    server.run()
+
+
+if __name__ == "__main__":
+    run()

--- a/mockjira/routers/__init__.py
+++ b/mockjira/routers/__init__.py
@@ -1,0 +1,10 @@
+"""FastAPI routers for the mock Jira server."""
+
+from . import agile, platform, service_management, webhooks  # noqa: F401
+
+__all__ = [
+    "agile",
+    "platform",
+    "service_management",
+    "webhooks",
+]

--- a/mockjira/routers/agile.py
+++ b/mockjira/routers/agile.py
@@ -1,0 +1,86 @@
+"""Subset of Jira Software (agile) APIs."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from ..auth import get_current_user
+from ..store import InMemoryStore
+from ..utils import paginate
+
+router = APIRouter(tags=["Agile"])
+
+
+def get_store(request: Request) -> InMemoryStore:
+    return request.app.state.store
+
+
+@router.get("/board")
+async def list_boards(
+    request: Request,
+    start_at: int = Query(default=0, alias="startAt"),
+    max_results: int = Query(default=50, alias="maxResults"),
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    page = paginate(store.list_boards(), start_at, max_results)
+    return {
+        "startAt": page["startAt"],
+        "maxResults": page["maxResults"],
+        "total": page["total"],
+        "isLast": page["isLast"],
+        "values": page["values"],
+    }
+
+
+@router.get("/board/{board_id}/sprint")
+async def list_sprints(
+    board_id: int,
+    request: Request,
+    start_at: int = Query(default=0, alias="startAt"),
+    max_results: int = Query(default=50, alias="maxResults"),
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    sprints = store.list_sprints(board_id)
+    page = paginate(sprints, start_at, max_results)
+    return {
+        "startAt": page["startAt"],
+        "maxResults": page["maxResults"],
+        "total": page["total"],
+        "isLast": page["isLast"],
+        "values": page["values"],
+    }
+
+
+@router.post("/sprint", status_code=status.HTTP_201_CREATED)
+async def create_sprint(
+    payload: dict,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    sprint = store.create_sprint(payload)
+    return sprint.to_api()
+
+
+@router.get("/board/{board_id}/backlog")
+async def backlog(
+    board_id: int,
+    request: Request,
+    start_at: int = Query(default=0, alias="startAt"),
+    max_results: int = Query(default=50, alias="maxResults"),
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    if board_id not in store.boards:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Board not found")
+    issues = store.backlog_issues(board_id)
+    page = paginate([issue.to_api(store) for issue in issues], start_at, max_results)
+    return {
+        "startAt": page["startAt"],
+        "maxResults": page["maxResults"],
+        "total": page["total"],
+        "isLast": page["isLast"],
+        "issues": page["values"],
+    }

--- a/mockjira/routers/platform.py
+++ b/mockjira/routers/platform.py
@@ -1,0 +1,202 @@
+"""Subset of the Jira platform REST API implemented for the mock server."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from ..auth import get_current_user
+from ..store import InMemoryStore
+from ..utils import paginate, parse_jql
+
+router = APIRouter(tags=["Platform"])
+
+
+def get_store(request: Request) -> InMemoryStore:
+    return request.app.state.store
+
+
+@router.get("/project")
+async def list_projects(
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    return {"values": store.list_projects()}
+
+
+@router.get("/field")
+async def list_fields(
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    return {"values": store.fields_payload()}
+
+
+@router.get("/status")
+async def list_statuses(
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    return {"values": get_store(request).list_statuses()}
+
+
+@router.get("/issue/{issue_id_or_key}")
+async def get_issue(
+    issue_id_or_key: str,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    issue = store.get_issue(issue_id_or_key)
+    if not issue:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    return issue.to_api(store)
+
+
+@router.post("/issue", status_code=status.HTTP_201_CREATED)
+async def create_issue(
+    payload: dict,
+    request: Request,
+    account_id: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    try:
+        issue = store.create_issue(payload, reporter_id=account_id)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return issue.to_api(store)
+
+
+@router.put("/issue/{issue_id_or_key}")
+async def update_issue(
+    issue_id_or_key: str,
+    payload: dict,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    issue = store.get_issue(issue_id_or_key)
+    if not issue:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    issue = store.update_issue(issue_id_or_key, payload)
+    return issue.to_api(store)
+
+
+@router.get("/search")
+async def search_issues(
+    request: Request,
+    jql: str | None = Query(default=None),
+    start_at: int = Query(default=0, alias="startAt"),
+    max_results: int = Query(default=50, alias="maxResults"),
+    account_id: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    filters = parse_jql(jql)
+
+    def _convert_assignee(value: str) -> str:
+        if value.lower() == "currentuser()":
+            return account_id
+        if value.lower() == "unassigned":
+            return "unassigned"
+        return value
+
+    assignee_filter = filters.get("assignee")
+    if isinstance(assignee_filter, list):
+        filters["assignee"] = [_convert_assignee(v) for v in assignee_filter]
+    elif isinstance(assignee_filter, str):
+        filters["assignee"] = _convert_assignee(assignee_filter)
+
+    results = store.search_issues(filters)
+    page = paginate(results, start_at, max_results)
+    return {
+        "startAt": page["startAt"],
+        "maxResults": page["maxResults"],
+        "total": page["total"],
+        "isLast": page["isLast"],
+        "issues": [issue.to_api(store) for issue in page["values"]],
+    }
+
+
+@router.get("/issue/{issue_id_or_key}/transitions")
+async def list_transitions(
+    issue_id_or_key: str,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    issue = store.get_issue(issue_id_or_key)
+    if not issue:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    transitions = store.get_transitions(issue)
+    return {"transitions": [t.to_api() for t in transitions]}
+
+
+@router.post("/issue/{issue_id_or_key}/transitions")
+async def apply_transition(
+    issue_id_or_key: str,
+    payload: dict,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    issue = store.get_issue(issue_id_or_key)
+    if not issue:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    transition_data = payload.get("transition", {})
+    transition_id = transition_data.get("id")
+    if not transition_id:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Missing transition id")
+    try:
+        issue = store.apply_transition(issue, transition_id)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return {"issue": issue.to_api(store)}
+
+
+@router.get("/issue/{issue_id_or_key}/comment")
+async def list_comments(
+    issue_id_or_key: str,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    issue = store.get_issue(issue_id_or_key)
+    if not issue:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    comments = [
+        comment.to_api(store.users[comment.author_id]) for comment in issue.comments
+    ]
+    return {
+        "startAt": 0,
+        "maxResults": len(comments),
+        "total": len(comments),
+        "comments": comments,
+    }
+
+
+@router.post("/issue/{issue_id_or_key}/comment", status_code=status.HTTP_201_CREATED)
+async def create_comment(
+    issue_id_or_key: str,
+    payload: dict,
+    request: Request,
+    account_id: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    issue = store.get_issue(issue_id_or_key)
+    if not issue:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Issue not found")
+    body = payload.get("body")
+    if not body:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Missing body")
+    comment = store.add_comment(issue, author_id=account_id, body=body)
+    return comment.to_api(store.users[account_id])
+
+
+@router.get("/myself")
+async def get_myself(
+    request: Request,
+    account_id: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    return store.users[account_id].to_api()

--- a/mockjira/routers/service_management.py
+++ b/mockjira/routers/service_management.py
@@ -1,0 +1,77 @@
+"""Subset of Jira Service Management APIs."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from ..auth import get_current_user
+from ..store import InMemoryStore
+from ..utils import paginate
+
+router = APIRouter(tags=["Service Management"])
+
+
+def get_store(request: Request) -> InMemoryStore:
+    return request.app.state.store
+
+
+@router.get("/request")
+async def list_requests(
+    request: Request,
+    start_at: int = Query(default=0, alias="start"),
+    page_size: int = Query(default=50, alias="limit"),
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    items = store.list_service_requests()
+    page = paginate(items, start_at, page_size)
+    return {
+        "values": page["values"],
+        "size": page["total"],
+        "start": page["startAt"],
+        "isLast": page["isLast"],
+    }
+
+
+@router.post("/request", status_code=status.HTTP_201_CREATED)
+async def create_request(
+    payload: dict,
+    request: Request,
+    account_id: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    service_request = store.create_service_request(payload, reporter_id=account_id)
+    issue = store.issues[service_request.issue_key]
+    return service_request.to_api(issue, store)
+
+
+@router.get("/request/{request_id}")
+async def get_request(
+    request_id: str,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    service_request = store.service_requests.get(request_id)
+    if not service_request:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Request not found")
+    issue = store.issues[service_request.issue_key]
+    return service_request.to_api(issue, store)
+
+
+@router.post("/request/{request_id}/approval/{approval_id}")
+async def update_approval(
+    request_id: str,
+    approval_id: str,
+    payload: dict,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    approve = payload.get("decision", "approve").lower() == "approve"
+    try:
+        service_request = store.update_service_request(request_id, approval_id, approve)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    issue = store.issues[service_request.issue_key]
+    return service_request.to_api(issue, store)

--- a/mockjira/routers/webhooks.py
+++ b/mockjira/routers/webhooks.py
@@ -1,0 +1,55 @@
+"""Webhook registration and inspection endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from ..auth import get_current_user
+from ..store import InMemoryStore
+
+router = APIRouter(tags=["Webhooks"])
+
+
+def get_store(request: Request) -> InMemoryStore:
+    return request.app.state.store
+
+
+@router.post("/webhook", status_code=status.HTTP_201_CREATED)
+async def register_webhook(
+    payload: dict,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    return {"webhookRegistrationResult": store.register_webhook(payload)}
+
+
+@router.get("/webhook")
+async def list_webhook(
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    return {"values": store.list_webhooks()}
+
+
+@router.delete("/webhook/{webhook_id}")
+async def delete_webhook(
+    webhook_id: str,
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    if webhook_id not in store.webhooks:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Webhook not found")
+    store.delete_webhook(webhook_id)
+    return {"status": "deleted"}
+
+
+@router.get("/_mock/webhooks/deliveries")
+async def list_deliveries(
+    request: Request,
+    _: str = Depends(get_current_user),
+) -> dict:
+    store = get_store(request)
+    return {"values": store.deliveries}

--- a/mockjira/store.py
+++ b/mockjira/store.py
@@ -1,0 +1,854 @@
+"""In-memory persistence layer for the mock Jira server."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+
+
+class RateLimitError(Exception):
+    """Raised when a token exceeds its allowed request budget."""
+
+    def __init__(self, retry_after: int) -> None:
+        self.retry_after = retry_after
+        super().__init__("Rate limit exceeded")
+
+
+@dataclass
+class User:
+    account_id: str
+    display_name: str
+    email: str
+    time_zone: str = "UTC"
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "accountId": self.account_id,
+            "displayName": self.display_name,
+            "emailAddress": self.email,
+            "timeZone": self.time_zone,
+            "active": True,
+        }
+
+
+@dataclass
+class Project:
+    id: str
+    key: str
+    name: str
+    project_type: str
+    lead_account_id: str
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "key": self.key,
+            "name": self.name,
+            "projectTypeKey": self.project_type,
+            "lead": {
+                **self.to_user_api(self.lead_account_id),
+            },
+        }
+
+    def to_user_api(self, account_id: str) -> dict[str, Any]:
+        return {
+            "accountId": account_id,
+        }
+
+
+@dataclass
+class IssueType:
+    id: str
+    name: str
+    subtask: bool = False
+
+    def to_api(self) -> dict[str, Any]:
+        return {"id": self.id, "name": self.name, "subtask": self.subtask}
+
+
+@dataclass
+class StatusCategory:
+    id: int
+    key: str
+    name: str
+
+    def to_api(self) -> dict[str, Any]:
+        return {"id": self.id, "key": self.key, "name": self.name}
+
+
+@dataclass
+class Status:
+    id: str
+    name: str
+    status_category: StatusCategory
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "statusCategory": self.status_category.to_api(),
+        }
+
+
+@dataclass
+class Transition:
+    id: str
+    name: str
+    to_status: Status
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "to": self.to_status.to_api(),
+        }
+
+
+@dataclass
+class Comment:
+    id: str
+    author_id: str
+    body: dict[str, Any]
+    created: datetime
+
+    def to_api(self, author: User) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "body": self.body,
+            "author": author.to_api(),
+            "created": self.created.isoformat(),
+            "updated": self.created.isoformat(),
+        }
+
+
+@dataclass
+class Sprint:
+    id: int
+    board_id: int
+    name: str
+    state: str
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    goal: str | None = None
+
+    def to_api(self) -> dict[str, Any]:
+        payload = {
+            "id": self.id,
+            "name": self.name,
+            "state": self.state,
+            "originBoardId": self.board_id,
+        }
+        if self.start_date:
+            payload["startDate"] = self.start_date.isoformat()
+        if self.end_date:
+            payload["endDate"] = self.end_date.isoformat()
+        if self.goal:
+            payload["goal"] = self.goal
+        return payload
+
+
+@dataclass
+class Board:
+    id: int
+    name: str
+    type: str
+    project_key: str
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "type": self.type,
+            "location": {"projectKey": self.project_key},
+        }
+
+
+@dataclass
+class ServiceRequest:
+    id: str
+    issue_key: str
+    request_type_id: str
+    approvals: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_api(self, issue: "Issue", store: "InMemoryStore") -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "issueId": issue.id,
+            "issueKey": issue.key,
+            "serviceDeskId": "1",
+            "requestTypeId": self.request_type_id,
+            "status": issue.status(store).to_api(),
+            "requestFieldValues": {
+                "summary": issue.summary,
+                "description": issue.description,
+            },
+            "approvals": self.approvals,
+        }
+
+
+@dataclass
+class Issue:
+    id: str
+    key: str
+    project_key: str
+    issue_type_id: str
+    summary: str
+    description: dict[str, Any]
+    status_id: str
+    reporter_id: str
+    assignee_id: str | None
+    labels: list[str] = field(default_factory=list)
+    created: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated: datetime = field(default_factory=lambda: datetime.now(UTC))
+    sprint_id: int | None = None
+    comments: list[Comment] = field(default_factory=list)
+
+    def project(self, store: "InMemoryStore") -> Project:
+        return store.projects[self.project_key]
+
+    def issue_type(self, store: "InMemoryStore") -> IssueType:
+        return store.issue_types[self.issue_type_id]
+
+    def status(self, store: "InMemoryStore") -> Status:
+        return store.statuses[self.status_id]
+
+    def reporter(self, store: "InMemoryStore") -> User:
+        return store.users[self.reporter_id]
+
+    def assignee(self, store: "InMemoryStore") -> User | None:
+        return store.users.get(self.assignee_id) if self.assignee_id else None
+
+    def to_api(self, store: "InMemoryStore") -> dict[str, Any]:
+        assignee = self.assignee(store)
+        reporter = self.reporter(store)
+        project = self.project(store)
+        fields = {
+            "summary": self.summary,
+            "description": self.description,
+            "issuetype": self.issue_type(store).to_api(),
+            "project": {
+                "id": project.id,
+                "key": project.key,
+                "name": project.name,
+                "projectTypeKey": project.project_type,
+            },
+            "status": self.status(store).to_api(),
+            "reporter": reporter.to_api(),
+            "assignee": assignee.to_api() if assignee else None,
+            "labels": self.labels,
+            "created": self.created.isoformat(),
+            "updated": self.updated.isoformat(),
+            "comment": {
+                "comments": [
+                    c.to_api(store.users[c.author_id]) for c in self.comments
+                ],
+                "total": len(self.comments),
+            },
+        }
+        if self.sprint_id:
+            fields["customfield_10020"] = [self.sprint_id]
+        return {
+            "id": self.id,
+            "key": self.key,
+            "fields": fields,
+        }
+
+
+@dataclass
+class WebhookRegistration:
+    id: str
+    url: str
+    events: list[str]
+    jql: str | None
+
+
+class InMemoryStore:
+    """Central state container for the mock server."""
+
+    def __init__(self) -> None:
+        self.users: dict[str, User] = {}
+        self.projects: dict[str, Project] = {}
+        self.issue_types: dict[str, IssueType] = {}
+        self.status_categories: dict[str, StatusCategory] = {}
+        self.statuses: dict[str, Status] = {}
+        self.transitions: dict[str, list[Transition]] = {}
+        self.issues: dict[str, Issue] = {}
+        self.issue_counter: dict[str, int] = defaultdict(int)
+        self.boards: dict[int, Board] = {}
+        self.sprints: dict[int, Sprint] = {}
+        self.service_requests: dict[str, ServiceRequest] = {}
+        self.webhooks: dict[str, WebhookRegistration] = {}
+        self.deliveries: list[dict[str, Any]] = []
+        self.tokens: dict[str, str] = {}
+        self.rate_calls: dict[str, deque[datetime]] = defaultdict(deque)
+        self.next_issue_id = 10000
+        self.next_comment_id = 20000
+        self.next_request_id = 30000
+        self.next_webhook_id = 40000
+        self.next_sprint_id = 5000
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+    @classmethod
+    def with_seed_data(cls) -> "InMemoryStore":
+        store = cls()
+        store._seed()
+        return store
+
+    # ------------------------------------------------------------------
+    def _seed(self) -> None:
+        self.tokens = {"mock-token": "5b10a2844c20165700ede21g"}
+
+        self.users = {
+            "5b10a2844c20165700ede21g": User(
+                account_id="5b10a2844c20165700ede21g",
+                display_name="Alice Johnson",
+                email="alice@example.com",
+            ),
+            "5b10a2844c20165700ede20f": User(
+                account_id="5b10a2844c20165700ede20f",
+                display_name="Bob Smith",
+                email="bob@example.com",
+            ),
+            "5b10a2844c20165700ede20e": User(
+                account_id="5b10a2844c20165700ede20e",
+                display_name="Carol Williams",
+                email="carol@example.com",
+            ),
+        }
+
+        to_do = StatusCategory(id=2, key="new", name="To Do")
+        in_progress = StatusCategory(id=4, key="indeterminate", name="In Progress")
+        done_cat = StatusCategory(id=3, key="done", name="Done")
+        self.status_categories = {
+            "todo": to_do,
+            "in_progress": in_progress,
+            "done": done_cat,
+        }
+
+        status_to_do = Status(id="1", name="To Do", status_category=to_do)
+        status_in_progress = Status(
+            id="3", name="In Progress", status_category=in_progress
+        )
+        status_done = Status(id="4", name="Done", status_category=done_cat)
+        self.statuses = {
+            status_to_do.id: status_to_do,
+            status_in_progress.id: status_in_progress,
+            status_done.id: status_done,
+        }
+
+        self.transitions = {
+            status_to_do.id: [
+                Transition(id="11", name="Start Progress", to_status=status_in_progress)
+            ],
+            status_in_progress.id: [
+                Transition(id="21", name="Resolve", to_status=status_done),
+                Transition(id="31", name="Reopen", to_status=status_to_do),
+            ],
+            status_done.id: [
+                Transition(id="41", name="Reopen", to_status=status_in_progress)
+            ],
+        }
+
+        self.projects = {
+            "DEV": Project(
+                id="10000",
+                key="DEV",
+                name="Development",
+                project_type="software",
+                lead_account_id="5b10a2844c20165700ede21g",
+            ),
+            "SUP": Project(
+                id="10001",
+                key="SUP",
+                name="Support",
+                project_type="service_desk",
+                lead_account_id="5b10a2844c20165700ede20f",
+            ),
+        }
+
+        self.issue_types = {
+            "10000": IssueType(id="10000", name="Bug"),
+            "10001": IssueType(id="10001", name="Task"),
+            "10002": IssueType(id="10002", name="Story"),
+            "10003": IssueType(id="10003", name="Service Request"),
+        }
+
+        self.boards = {
+            1: Board(id=1, name="DEV Scrum", type="scrum", project_key="DEV"),
+            2: Board(id=2, name="DEV Kanban", type="kanban", project_key="DEV"),
+        }
+
+        now = datetime.now(UTC)
+        self.sprints = {
+            1: Sprint(
+                id=1,
+                board_id=1,
+                name="Sprint 1",
+                state="closed",
+                start_date=now - timedelta(days=21),
+                end_date=now - timedelta(days=7),
+                goal="Initial release",
+            ),
+            2: Sprint(
+                id=2,
+                board_id=1,
+                name="Sprint 2",
+                state="active",
+                start_date=now - timedelta(days=6),
+                end_date=now + timedelta(days=8),
+                goal="Polish features",
+            ),
+            3: Sprint(
+                id=3,
+                board_id=1,
+                name="Sprint 3",
+                state="future",
+                start_date=now + timedelta(days=9),
+                end_date=now + timedelta(days=23),
+            ),
+        }
+        self.next_sprint_id = 4
+
+        self._create_issue(
+            project_key="DEV",
+            issue_type_id="10002",
+            summary="User can sign up",
+            description=self._adf("Implement sign-up flow"),
+            reporter_id="5b10a2844c20165700ede21g",
+            assignee_id="5b10a2844c20165700ede20f",
+            status_id="3",
+            labels=["backend"],
+            sprint_id=2,
+        )
+        self._create_issue(
+            project_key="DEV",
+            issue_type_id="10000",
+            summary="Fix payment bug",
+            description=self._adf("Resolve gateway timeout"),
+            reporter_id="5b10a2844c20165700ede20f",
+            assignee_id="5b10a2844c20165700ede21g",
+            status_id="1",
+            labels=["urgent"],
+        )
+        self._create_issue(
+            project_key="DEV",
+            issue_type_id="10001",
+            summary="Improve onboarding",
+            description=self._adf("Add product tour"),
+            reporter_id="5b10a2844c20165700ede21g",
+            assignee_id=None,
+            status_id="1",
+        )
+        self._create_issue(
+            project_key="SUP",
+            issue_type_id="10003",
+            summary="Cannot login",
+            description=self._adf("Customer reports login failure"),
+            reporter_id="5b10a2844c20165700ede20e",
+            assignee_id="5b10a2844c20165700ede20f",
+            status_id="1",
+        )
+
+        for issue in self.issues.values():
+            if issue.project_key == "SUP":
+                self._ensure_service_request(issue)
+
+    # ------------------------------------------------------------------
+    def _create_issue(
+        self,
+        project_key: str,
+        issue_type_id: str,
+        summary: str,
+        description: dict[str, Any],
+        reporter_id: str,
+        assignee_id: str | None,
+        status_id: str,
+        labels: list[str] | None = None,
+        sprint_id: int | None = None,
+    ) -> Issue:
+        seq = self.issue_counter[project_key] + 1
+        self.issue_counter[project_key] = seq
+        key = f"{project_key}-{seq}"
+        issue = Issue(
+            id=str(self.next_issue_id),
+            key=key,
+            project_key=project_key,
+            issue_type_id=issue_type_id,
+            summary=summary,
+            description=description,
+            status_id=status_id,
+            reporter_id=reporter_id,
+            assignee_id=assignee_id,
+            labels=labels or [],
+            sprint_id=sprint_id,
+        )
+        self.next_issue_id += 1
+        self.issues[key] = issue
+        return issue
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _adf(self, text: str) -> dict[str, Any]:
+        return {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": text}],
+                }
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def is_valid_token(self, token: str) -> bool:
+        return token in self.tokens
+
+    def register_call(self, token: str) -> None:
+        limit = 100
+        window = timedelta(seconds=60)
+        now = datetime.now(UTC)
+        bucket = self.rate_calls[token]
+        while bucket and now - bucket[0] > window:
+            bucket.popleft()
+        if len(bucket) >= limit:
+            retry_after = int((window - (now - bucket[0])).total_seconds())
+            raise RateLimitError(retry_after=retry_after)
+        bucket.append(now)
+
+    # ------------------------- Platform --------------------------------
+    def list_projects(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": proj.id,
+                "key": proj.key,
+                "name": proj.name,
+                "projectTypeKey": proj.project_type,
+            }
+            for proj in self.projects.values()
+        ]
+
+    def list_issue_types(self) -> list[dict[str, Any]]:
+        return [t.to_api() for t in self.issue_types.values()]
+
+    def list_statuses(self) -> list[dict[str, Any]]:
+        return [status.to_api() for status in self.statuses.values()]
+
+    def list_users(self, query: str | None = None) -> list[dict[str, Any]]:
+        query = (query or "").lower()
+        matches = [
+            user.to_api()
+            for user in self.users.values()
+            if query in user.display_name.lower() or query in user.email.lower()
+        ]
+        return matches
+
+    def fields_payload(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "summary",
+                "name": "Summary",
+                "schema": {"type": "string"},
+                "custom": False,
+            },
+            {
+                "id": "description",
+                "name": "Description",
+                "schema": {"type": "rich_text"},
+                "custom": False,
+            },
+            {
+                "id": "labels",
+                "name": "Labels",
+                "schema": {"type": "array", "items": "string"},
+                "custom": False,
+            },
+        ]
+
+    def get_issue(self, key: str) -> Issue | None:
+        return self.issues.get(key)
+
+    def create_issue(self, payload: dict[str, Any], reporter_id: str) -> Issue:
+        fields = payload.get("fields", {})
+        project = fields.get("project", {})
+        project_key = project.get("key")
+        if not project_key or project_key not in self.projects:
+            raise ValueError("Invalid or missing project key")
+        issue_type_id = fields.get("issuetype", {}).get("id") or "10001"
+        summary = fields.get("summary", "Untitled issue")
+        description = self.normalize_adf(fields.get("description", ""))
+        assignee_field = fields.get("assignee") or {}
+        assignee_id = assignee_field.get("accountId")
+        labels = fields.get("labels", [])
+        issue = self._create_issue(
+            project_key=project_key,
+            issue_type_id=issue_type_id,
+            summary=summary,
+            description=description,
+            reporter_id=reporter_id,
+            assignee_id=assignee_id,
+            status_id="1",
+            labels=labels,
+        )
+        if project_key == "SUP":
+            self._ensure_service_request(issue)
+        self.dispatch_event(
+            "jira:issue_created",
+            {"issue": issue.to_api(self)},
+        )
+        return issue
+
+    def update_issue(self, key: str, payload: dict[str, Any]) -> Issue:
+        issue = self.issues[key]
+        fields = payload.get("fields", {})
+        if "summary" in fields:
+            issue.summary = fields["summary"]
+        if "description" in fields:
+            issue.description = self.normalize_adf(fields["description"])
+        if "assignee" in fields:
+            assignee = fields.get("assignee")
+            issue.assignee_id = assignee.get("accountId") if assignee else None
+        if "labels" in fields:
+            issue.labels = list(fields["labels"])
+        issue.updated = datetime.now(UTC)
+        self.dispatch_event(
+            "jira:issue_updated",
+            {"issue": issue.to_api(self)},
+        )
+        return issue
+
+    def search_issues(self, filters: dict[str, Any]) -> list[Issue]:
+        results = list(self.issues.values())
+        project = filters.get("project")
+        if project:
+            if isinstance(project, list):
+                allowed = set(project)
+            else:
+                allowed = {project}
+            results = [i for i in results if i.project_key in allowed]
+        status = filters.get("status")
+        if status:
+            if isinstance(status, str):
+                status_values = {status.lower()}
+            else:
+                status_values = {s.lower() for s in status}
+            results = [
+                i
+                for i in results
+                if i.status(self).name.lower() in status_values
+            ]
+        assignee = filters.get("assignee")
+        if assignee:
+            if isinstance(assignee, str):
+                values = {assignee.lower()}
+            else:
+                values = {a.lower() for a in assignee}
+            results = [
+                i
+                for i in results
+                if (i.assignee_id or "unassigned").lower() in values
+            ]
+        return sorted(results, key=lambda i: i.created)
+
+    def get_transitions(self, issue: Issue) -> list[Transition]:
+        return self.transitions.get(issue.status_id, [])
+
+    def apply_transition(self, issue: Issue, transition_id: str) -> Issue:
+        transitions = self.get_transitions(issue)
+        for transition in transitions:
+            if transition.id == transition_id:
+                issue.status_id = transition.to_status.id
+                issue.updated = datetime.now(UTC)
+                self.dispatch_event(
+                    "jira:issue_updated",
+                    {"issue": issue.to_api(self)},
+                )
+                return issue
+        raise ValueError("Invalid transition")
+
+    def add_comment(self, issue: Issue, author_id: str, body: Any) -> Comment:
+        comment = Comment(
+            id=str(self.next_comment_id),
+            author_id=author_id,
+            body=self.normalize_adf(body),
+            created=datetime.now(UTC),
+        )
+        self.next_comment_id += 1
+        issue.comments.append(comment)
+        issue.updated = datetime.now(UTC)
+        self.dispatch_event(
+            "comment_created",
+            {"issue": issue.to_api(self), "comment": comment.to_api(self.users[author_id])},
+        )
+        return comment
+
+    # --------------------------- Agile ---------------------------------
+    def list_boards(self) -> list[dict[str, Any]]:
+        return [board.to_api() for board in self.boards.values()]
+
+    def list_sprints(self, board_id: int) -> list[dict[str, Any]]:
+        return [s.to_api() for s in self.sprints.values() if s.board_id == board_id]
+
+    def create_sprint(self, payload: dict[str, Any]) -> Sprint:
+        sprint = Sprint(
+            id=self.next_sprint_id,
+            board_id=payload.get("originBoardId", 1),
+            name=payload.get("name", f"Sprint {self.next_sprint_id}"),
+            state=payload.get("state", "future"),
+            start_date=self._parse_datetime(payload.get("startDate")),
+            end_date=self._parse_datetime(payload.get("endDate")),
+            goal=payload.get("goal"),
+        )
+        self.sprints[sprint.id] = sprint
+        self.next_sprint_id += 1
+        return sprint
+
+    def backlog_issues(self, board_id: int) -> list[Issue]:
+        board = self.boards.get(board_id)
+        if not board:
+            return []
+        project_key = board.project_key
+        return [
+            issue
+            for issue in self.issues.values()
+            if issue.project_key == project_key and issue.sprint_id is None
+        ]
+
+    # ------------------------ Service Desk -----------------------------
+    def list_service_requests(self) -> list[dict[str, Any]]:
+        payloads = []
+        for req in self.service_requests.values():
+            issue = self.issues[req.issue_key]
+            payloads.append(req.to_api(issue, self))
+        return payloads
+
+    def create_service_request(
+        self, payload: dict[str, Any], reporter_id: str
+    ) -> ServiceRequest:
+        field_values = payload.get("requestFieldValues", {})
+        summary = field_values.get("summary", "Support request")
+        description = field_values.get("description", "")
+        issue = self._create_issue(
+            project_key="SUP",
+            issue_type_id="10003",
+            summary=summary,
+            description=self.normalize_adf(description),
+            reporter_id=reporter_id,
+            assignee_id=None,
+            status_id="1",
+        )
+        service_request = self._ensure_service_request(issue)
+        self.dispatch_event(
+            "jira:issue_created",
+            {"issue": issue.to_api(self)},
+        )
+        return service_request
+
+    def update_service_request(
+        self, request_id: str, approval_id: str, approve: bool
+    ) -> ServiceRequest:
+        request = self.service_requests.get(request_id)
+        if not request:
+            raise ValueError("Unknown service request")
+        decision = "approved" if approve else "declined"
+        approval_record = {
+            "id": approval_id,
+            "decision": decision,
+            "decider": self.users[next(iter(self.users))].to_api(),
+        }
+        request.approvals.append(approval_record)
+        issue = self.issues[request.issue_key]
+        issue.status_id = "4" if approve else "3"
+        issue.updated = datetime.now(UTC)
+        self.dispatch_event(
+            "jira:issue_updated",
+            {"issue": issue.to_api(self)},
+        )
+        return request
+
+    # -------------------------- Webhooks -------------------------------
+    def register_webhook(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        registrations = []
+        for body in payload.get("webhooks", []):
+            webhook_id = str(self.next_webhook_id)
+            self.next_webhook_id += 1
+            registration = WebhookRegistration(
+                id=webhook_id,
+                url=body.get("url"),
+                events=body.get("events", []),
+                jql=body.get("jql"),
+            )
+            self.webhooks[webhook_id] = registration
+            registrations.append(
+                {"createdWebhookId": webhook_id, "failureReason": None}
+            )
+        return registrations
+
+    def list_webhooks(self) -> list[dict[str, Any]]:
+        return [
+            {"id": reg.id, "url": reg.url, "events": reg.events, "jql": reg.jql}
+            for reg in self.webhooks.values()
+        ]
+
+    def delete_webhook(self, webhook_id: str) -> None:
+        self.webhooks.pop(webhook_id, None)
+
+    def dispatch_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        delivery = {
+            "event": event_type,
+            "payload": payload,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+        self.deliveries.append(delivery)
+        for registration in self.webhooks.values():
+            if event_type not in registration.events:
+                continue
+            self._send_webhook(registration.url, delivery)
+
+    def _send_webhook(self, url: str | None, delivery: dict[str, Any]) -> None:
+        if not url:
+            return
+        try:
+            with httpx.Client(timeout=0.5) as client:
+                client.post(url, json=delivery)
+        except httpx.HTTPError:
+            # Fail silently; this is a mock server.
+            pass
+
+    # ------------------------ Utilities --------------------------------
+    def normalize_adf(self, value: Any) -> dict[str, Any]:
+        if isinstance(value, dict) and value.get("type") == "doc":
+            return value
+        if isinstance(value, str):
+            return self._adf(value)
+        raise ValueError("Unsupported ADF payload")
+
+    def _ensure_service_request(self, issue: Issue) -> ServiceRequest:
+        request_id = str(self.next_request_id)
+        self.next_request_id += 1
+        service_request = ServiceRequest(
+            id=request_id,
+            issue_key=issue.key,
+            request_type_id="100",
+        )
+        self.service_requests[request_id] = service_request
+        return service_request
+
+    def _parse_datetime(self, value: Any) -> datetime | None:
+        if not value:
+            return None
+        if isinstance(value, datetime):
+            return value
+        try:
+            return datetime.fromisoformat(value)
+        except Exception:  # pragma: no cover - invalid date fallback
+            return None

--- a/mockjira/utils.py
+++ b/mockjira/utils.py
@@ -1,0 +1,71 @@
+"""Utility helpers for the mock Jira server."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+
+_JQL_IN_PATTERN = re.compile(r"^(?P<field>[\w.]+)\s+IN\s*\((?P<values>[^)]*)\)$", re.IGNORECASE)
+_JQL_EQUALS_PATTERN = re.compile(r"^(?P<field>[\w.]+)\s*=\s*(?P<value>.+)$")
+
+
+def parse_jql(jql: str | None) -> dict[str, Any]:
+    """Parse a very small subset of JQL into a dictionary of filters."""
+
+    if not jql:
+        return {}
+    raw = jql.strip()
+    if not raw:
+        return {}
+
+    # Ignore ORDER BY clause.
+    raw = raw.split("ORDER BY", 1)[0].strip()
+
+    filters: dict[str, Any] = {}
+    clauses = re.split(r"\s+AND\s+", raw, flags=re.IGNORECASE)
+    for clause in clauses:
+        clause = clause.strip()
+        if not clause:
+            continue
+        in_match = _JQL_IN_PATTERN.match(clause)
+        if in_match:
+            field = in_match.group("field").lower()
+            values = [
+                _normalise_value(v)
+                for v in in_match.group("values").split(",")
+                if v.strip()
+            ]
+            filters[field] = values
+            continue
+        eq_match = _JQL_EQUALS_PATTERN.match(clause)
+        if eq_match:
+            field = eq_match.group("field").lower()
+            value = _normalise_value(eq_match.group("value"))
+            filters[field] = value
+    return filters
+
+
+def _normalise_value(raw: str) -> str:
+    value = raw.strip()
+    if value.startswith("\"") and value.endswith("\""):
+        value = value[1:-1]
+    if value.startswith("'") and value.endswith("'"):
+        value = value[1:-1]
+    return value
+
+
+def paginate(items: Iterable[Any], start_at: int, max_results: int) -> dict[str, Any]:
+    sequence = list(items)
+    total = len(sequence)
+    start_at = max(start_at, 0)
+    max_results = max(0, max_results)
+    page = sequence[start_at : start_at + max_results] if max_results else []
+    is_last = start_at + len(page) >= total
+    return {
+        "startAt": start_at,
+        "maxResults": max_results,
+        "total": total,
+        "isLast": is_last,
+        "values": page,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mock-jira-server"
+version = "0.1.0"
+description = "Stateful mock server for Jira Cloud APIs"
+authors = [{name = "AI Assistant"}]
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.111",
+    "uvicorn[standard]>=0.29",
+    "pydantic>=2.7",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.2",
+    "pytest-asyncio>=0.23",
+    "anyio>=4.4",
+]
+
+[project.scripts]
+mock-jira-server = "mockjira.main:run"

--- a/tests/test_mockjira.py
+++ b/tests/test_mockjira.py
@@ -1,0 +1,170 @@
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from mockjira.app import create_app
+from mockjira.store import InMemoryStore
+
+AUTH_HEADERS = {"Authorization": "Bearer mock-token"}
+
+
+@pytest.fixture()
+def app():
+    store = InMemoryStore.with_seed_data()
+    return create_app(store)
+
+
+@pytest_asyncio.fixture()
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_projects_and_fields(client):
+    resp = await client.get("/rest/api/3/project", headers=AUTH_HEADERS)
+    assert resp.status_code == 200
+    projects = resp.json()["values"]
+    assert any(project["key"] == "DEV" for project in projects)
+
+    resp = await client.get("/rest/api/3/field", headers=AUTH_HEADERS)
+    assert resp.status_code == 200
+    fields = resp.json()["values"]
+    assert any(field["id"] == "summary" for field in fields)
+
+
+@pytest.mark.asyncio
+async def test_issue_lifecycle_and_webhook_delivery(client):
+    issue_payload = {
+        "fields": {
+            "project": {"key": "DEV"},
+            "summary": "Automated test issue",
+            "description": "Created from tests",
+            "issuetype": {"id": "10001"},
+        }
+    }
+    create_resp = await client.post(
+        "/rest/api/3/issue", json=issue_payload, headers=AUTH_HEADERS
+    )
+    assert create_resp.status_code == 201
+    issue = create_resp.json()
+
+    get_resp = await client.get(
+        f"/rest/api/3/issue/{issue['key']}", headers=AUTH_HEADERS
+    )
+    assert get_resp.status_code == 200
+    assert get_resp.json()["fields"]["summary"] == "Automated test issue"
+
+    search_resp = await client.get(
+        "/rest/api/3/search",
+        params={"jql": "project = DEV AND status = \"To Do\""},
+        headers=AUTH_HEADERS,
+    )
+    assert search_resp.status_code == 200
+    issues = [i["key"] for i in search_resp.json()["issues"]]
+    assert issue["key"] in issues
+
+    transitions_resp = await client.get(
+        f"/rest/api/3/issue/{issue['key']}/transitions", headers=AUTH_HEADERS
+    )
+    transition_id = transitions_resp.json()["transitions"][0]["id"]
+    apply_resp = await client.post(
+        f"/rest/api/3/issue/{issue['key']}/transitions",
+        json={"transition": {"id": transition_id}},
+        headers=AUTH_HEADERS,
+    )
+    assert apply_resp.status_code == 200
+
+    comment_resp = await client.post(
+        f"/rest/api/3/issue/{issue['key']}/comment",
+        json={"body": "Looks good"},
+        headers=AUTH_HEADERS,
+    )
+    assert comment_resp.status_code == 201
+    comments = await client.get(
+        f"/rest/api/3/issue/{issue['key']}/comment", headers=AUTH_HEADERS
+    )
+    assert comments.status_code == 200
+    assert comments.json()["total"] == 1
+
+    deliveries_resp = await client.get(
+        "/rest/api/3/_mock/webhooks/deliveries", headers=AUTH_HEADERS
+    )
+    deliveries = deliveries_resp.json()["values"]
+    assert any(delivery["event"] == "jira:issue_created" for delivery in deliveries)
+
+
+@pytest.mark.asyncio
+async def test_agile_endpoints(client):
+    board_resp = await client.get("/rest/agile/1.0/board", headers=AUTH_HEADERS)
+    assert board_resp.status_code == 200
+    boards = board_resp.json()["values"]
+    assert boards
+
+    backlog_resp = await client.get(
+        "/rest/agile/1.0/board/1/backlog", headers=AUTH_HEADERS
+    )
+    assert backlog_resp.status_code == 200
+    assert "issues" in backlog_resp.json()
+
+    sprint_resp = await client.post(
+        "/rest/agile/1.0/sprint",
+        json={"originBoardId": 1, "name": "QA Sprint"},
+        headers=AUTH_HEADERS,
+    )
+    assert sprint_resp.status_code == 201
+    assert sprint_resp.json()["name"] == "QA Sprint"
+
+
+@pytest.mark.asyncio
+async def test_service_management_flow(client):
+    create_resp = await client.post(
+        "/rest/servicedeskapi/request",
+        json={
+            "serviceDeskId": "1",
+            "requestTypeId": "100",
+            "requestFieldValues": {
+                "summary": "Need laptop",
+                "description": "New starter hardware request",
+            },
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert create_resp.status_code == 201
+    request_payload = create_resp.json()
+
+    approval_resp = await client.post(
+        f"/rest/servicedeskapi/request/{request_payload['id']}/approval/42",
+        json={"decision": "approve"},
+        headers=AUTH_HEADERS,
+    )
+    assert approval_resp.status_code == 200
+    assert approval_resp.json()["approvals"]
+
+
+@pytest.mark.asyncio
+async def test_webhook_registration(client):
+    register_resp = await client.post(
+        "/rest/api/3/webhook",
+        json={
+            "webhooks": [
+                {
+                    "url": "http://localhost/dummy",
+                    "events": ["jira:issue_created"],
+                }
+            ]
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert register_resp.status_code == 201
+    assert register_resp.json()["webhookRegistrationResult"]
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_simulation(client):
+    resp = await client.get(
+        "/rest/api/3/project",
+        headers={**AUTH_HEADERS, "X-Force-429": "true"},
+    )
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- add a FastAPI application with seeded in-memory state to emulate Jira Cloud issues, search, transitions, comments and authentication
- implement routers for Agile boards/sprints/backlog, Service Management requests and webhook registration plus delivery inspection
- provide pytest coverage for core workflows and document usage/setup in a README

## Testing
- python -m pip install -e .[test]
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cadd1cdc0c83309dd10a8b88b74f19