### PR TITLE
feat: reliability and parity pack v1 updates

### DIFF
--- a/mockjira/app.py
+++ b/mockjira/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from collections import deque
@@ -62,14 +63,11 @@ def create_app(store: InMemoryStore | None = None) -> FastAPI:
             "timestamp": start.isoformat(),
         }
         app.state.request_log.append(entry)
-        logger.info(
-            "REQ %s %s -> %s %.2fms req_id=%s",
-            request.method,
-            request.url.path,
-            response.status_code,
-            duration_ms,
-            req_id,
-        )
+        log_entry = {
+            **entry,
+            "message": "request",
+        }
+        logger.info(json.dumps(log_entry))
         return response
 
     app.include_router(platform.router, prefix="/rest/api/3")


### PR DESCRIPTION
## Summary
- expand JQL parsing and POST /search handling with ORDER BY defaults, currentUser resolution, and field/expand support
- tighten issue search, linking, and changelog responses with deterministic filters, date comparisons, and validated relationships
- harden webhook delivery via sha256 signature hashing, retry dedupe bookkeeping, replay improvements, and structured request logging

## Testing
- pytest tests/test_mockjira.py tests/test_errors_and_limits.py *(fails: legacy signature expectation prior to spec change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19d1a78c8330b285d8e98e072785