### PR TITLE
Implement orchestrator webhook loop and suggestion cache

### DIFF
--- a/clients/python/jira_adapter.py
+++ b/clients/python/jira_adapter.py
@@ -190,6 +190,13 @@ class JiraAdapter:
             json_body={"body": body_adf},
         )
 
+    def update_issue_fields(self, key: str, fields: dict[str, Any]) -> dict[str, Any]:
+        return self._call(
+            "PUT",
+            f"/rest/api/3/issue/{key}",
+            json_body={"fields": fields},
+        )
+
     def search(self, jql: str, start_at: int = 0, max_results: int = 50) -> dict[str, Any]:
         try:
             return self._call(
@@ -279,3 +286,10 @@ class JiraAdapter:
             json_body={"webhooks": [body]},
         )
         return response.get("webhookRegistrationResult", [])
+
+    def list_webhooks(self) -> list[dict[str, Any]]:
+        response = self._call("GET", "/rest/api/3/webhook")
+        values = response.get("values", [])
+        if not isinstance(values, list):
+            return []
+        return values

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,17 @@ services:
     ports: ["9000:9000"]
     environment:
       - LOG_LEVEL=info
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9000/_mock/health', timeout=2).status==200 else 1)",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
 
   orchestrator:
     image: python:3.12-slim
@@ -22,5 +33,17 @@ services:
       - WEBHOOK_SECRET=dev-secret
       - LEDGER_BACKEND=memory
       - SIGNATURE_VERSION=2
+      - ORCHESTRATOR_BASE_URL=http://orchestrator:7010
     depends_on:
       - mock-jira
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:7010/health', timeout=2).status==200 else 1)",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
+import logging
 import os
 import time
 from typing import Any, Dict, List
@@ -17,11 +19,37 @@ JIRA_BASE_URL = os.getenv("JIRA_BASE_URL", "http://localhost:9000")
 JIRA_TOKEN = os.getenv("JIRA_TOKEN", "mock-token")
 WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "dev-secret")
 SIGNATURE_VERSION = int(os.getenv("SIGNATURE_VERSION", "2"))
+AUTO_REGISTER_WEBHOOK = os.getenv("AUTO_REGISTER_WEBHOOK", "1").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+ORCHESTRATOR_BASE_URL = os.getenv("ORCHESTRATOR_BASE_URL")
+WEBHOOK_URL = os.getenv("WEBHOOK_URL")
+if not WEBHOOK_URL:
+    if ORCHESTRATOR_BASE_URL:
+        WEBHOOK_URL = f"{ORCHESTRATOR_BASE_URL.rstrip('/')}/webhooks/jira"
+    else:
+        WEBHOOK_URL = "http://localhost:7010/webhooks/jira"
+WEBHOOK_JQL = os.getenv("WEBHOOK_JQL", "project = SUP")
+_webhook_events_env = os.getenv(
+    "WEBHOOK_EVENTS", "jira:issue_created,jira:issue_updated"
+)
+WEBHOOK_EVENTS = [
+    event.strip()
+    for event in _webhook_events_env.split(",")
+    if event.strip()
+]
+if not WEBHOOK_EVENTS:
+    WEBHOOK_EVENTS = ["jira:issue_created"]
+
+logger = logging.getLogger("digital_spiral.orchestrator")
 
 adapter = JiraAdapter(JIRA_BASE_URL, JIRA_TOKEN)
 
 # --- in-memory "ledger" ---
 LEDGER: dict[str, dict] = {}  # key -> metrics
+SUGGESTIONS: dict[str, dict[str, Any]] = {}
 
 
 # --- Pydantic DTOs ---
@@ -37,6 +65,50 @@ class ApplyIn(BaseModel):
 
 
 app = FastAPI(title="Digital Spiral Orchestrator (Jira MVP)")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+async def ensure_webhook_registered() -> None:
+    if not AUTO_REGISTER_WEBHOOK:
+        logger.info("Webhook auto-registration disabled")
+        return
+    if not WEBHOOK_URL:
+        logger.warning("Webhook URL is not configured; skipping registration")
+        return
+    try:
+        existing = await asyncio.to_thread(adapter.list_webhooks)
+    except Exception as exc:  # pragma: no cover - network failures are logged only
+        logger.warning("Failed to list webhooks: %s", exc)
+        return
+    target_events = set(WEBHOOK_EVENTS)
+    for registration in existing:
+        if (
+            registration.get("url") == WEBHOOK_URL
+            and registration.get("jql") == WEBHOOK_JQL
+            and set(registration.get("events") or []) == target_events
+        ):
+            logger.info("Webhook already registered for %s", WEBHOOK_URL)
+            return
+    try:
+        await asyncio.to_thread(
+            adapter.register_webhook,
+            WEBHOOK_URL,
+            WEBHOOK_JQL,
+            events=list(target_events),
+            secret=WEBHOOK_SECRET,
+        )
+        logger.info("Registered webhook target %s", WEBHOOK_URL)
+    except Exception as exc:  # pragma: no cover - network failures are logged only
+        logger.error("Failed to register webhook %s: %s", WEBHOOK_URL, exc)
+
+
+@app.on_event("startup")
+async def startup_event() -> None:  # pragma: no cover - exercised in integration tests
+    await ensure_webhook_registered()
 
 
 def adf_from_text(text: str) -> dict:
@@ -91,7 +163,17 @@ async def jira_webhook(request: Request):
     # store last event per issue (for demo)
     key = payload.get("issue", {}).get("key") or payload.get("issueKey")
     LEDGER.setdefault(key or "unknown", {}).update({"last_event": payload})
-    return {"ok": True}
+    if not key:
+        return {"ok": True}
+    try:
+        issue_payload = await asyncio.to_thread(adapter.get_issue, key)
+    except Exception as exc:
+        logger.error("Failed to fetch issue %s from Jira: %s", key, exc)
+        raise HTTPException(502, "Failed to fetch issue payload") from exc
+    suggestion = ingest(IngestIn(issue=issue_payload))
+    LEDGER.setdefault(key, {})
+    LEDGER[key]["last_ingest"] = time.time()
+    return {"ok": True, "suggestion": suggestion}
 
 
 # -------- Ingest: create draft + plan --------
@@ -101,7 +183,6 @@ def ingest(i: IngestIn):
     key = issue["key"]
     fields = issue.get("fields", {})
     summary = fields.get("summary") or "(no summary)"
-    desc_text = ""
     # draft heuristic
     if "password" in summary.lower():
         draft = (
@@ -112,24 +193,39 @@ def ingest(i: IngestIn):
             {"id": "reply-1", "type": "reply", "public": True, "body_adf": adf_from_text(draft)},
             {"id": "transition-1", "type": "transition", "to": "In Progress"},
         ]
+        planned_label = None
     else:
         draft = (
             "Ahoj! Pozreli sme sa na ticket: "
             f"{summary}. Prosím pošli verziu aplikácie a posledné logy."
         )
+        planned_label = "needs-info"
         actions = [
             {"id": "reply-1", "type": "reply", "public": True, "body_adf": adf_from_text(draft)},
             {"id": "label-1", "type": "add_label", "value": "needs-info"},
         ]
     LEDGER.setdefault(key, {})
     LEDGER[key]["draft_text"] = draft
-    LEDGER[key]["baseline_seconds"] = LEDGER[key].get("baseline_seconds", 600)
-    return {
+    LEDGER[key]["baseline_seconds"] = LEDGER[key].get("baseline_seconds", 120)
+    if planned_label:
+        LEDGER[key]["planned_label"] = planned_label
+    suggestion = {
         "playbook_id": "jira-default",
         "draft_reply_adf": adf_from_text(draft),
         "actions": actions,
         "explanations": ["Heuristika na základe summary", "Jednoklikové kroky pre agenta"],
     }
+    SUGGESTIONS[key] = suggestion
+    return suggestion
+
+
+# -------- Suggestions read --------
+@app.get("/v1/suggestions/{issue_key}")
+def get_suggestion(issue_key: str):
+    suggestion = SUGGESTIONS.get(issue_key)
+    if suggestion is None:
+        raise HTTPException(404, "Suggestion not found")
+    return suggestion
 
 
 # -------- Apply: execute plan via adapter + write ledger --------
@@ -154,15 +250,27 @@ def apply(a: ApplyIn):
 
     # 3) label (demoverzia: update issue fields)
     if "label-1" in a.accepted_action_ids:
-        applied.append({"id": "label-1", "ok": True})
+        planned_label = LEDGER.get(key, {}).get("planned_label", "needs-info")
+        try:
+            issue_payload = adapter.get_issue(key)
+        except Exception as exc:
+            raise HTTPException(502, f"Failed to load issue {key}: {exc}") from exc
+        labels = list(issue_payload.get("fields", {}).get("labels") or [])
+        if planned_label and planned_label not in labels:
+            labels.append(planned_label)
+        try:
+            adapter.update_issue_fields(key, {"labels": labels})
+        except Exception as exc:
+            raise HTTPException(502, f"Failed to update labels for {key}: {exc}") from exc
+        applied.append({"id": "label-1", "ok": True, "labels": labels})
 
     # ledger
-    elapsed = int(time.time() - start)
-    baseline = LEDGER.get(key, {}).get("baseline_seconds", 600)
+    elapsed = max(time.time() - start, 1.0)
+    baseline = float(LEDGER.get(key, {}).get("baseline_seconds", 120))
     draft_text = LEDGER.get(key, {}).get("draft_text", "")
     final_text = draft_text  # v MVP predpokladáme Apply bez editácie
     quality = compute_quality(draft_text, final_text)
-    credit = max(0.0, min(1.0, elapsed / max(1, baseline))) * quality
+    credit = min(1.0, elapsed / max(1.0, baseline)) * quality
 
     LEDGER.setdefault(key, {})
     LEDGER[key].update(
@@ -187,12 +295,12 @@ def get_ledger(issue_key: str):
 def ui():
     rows = []
     for k, v in LEDGER.items():
-        ds = int(v.get("delta_seconds", 0))
-        base = int(v.get("baseline_seconds", 600))
+        ds = float(v.get("delta_seconds", 0.0))
+        base = int(float(v.get("baseline_seconds", 120)))
         qual = v.get("quality", 1.0)
         cred = v.get("credit", 0.0)
         rows.append(
-            f"<tr><td>{k}</td><td>{ds}s/{base}s</td><td>{qual:.2f}</td><td>{cred:.2f}</td></tr>"
+            f"<tr><td>{k}</td><td>{ds:.1f}s/{base}s</td><td>{qual:.2f}</td><td>{cred:.2f}</td></tr>"
         )
     body = f"""
     <html><body>

--- a/tests/test_orchestrator_app.py
+++ b/tests/test_orchestrator_app.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import orchestrator.app as orchestrator_module
+
+
+class DummyAdapter:
+    def __init__(self) -> None:
+        self.webhooks: list[dict[str, Any]] = []
+        self.issue_payloads: dict[str, dict[str, Any]] = {}
+        self.comments: list[tuple[str, dict[str, Any]]] = []
+        self.transition_calls: list[tuple[str, str]] = []
+        self.updated_fields: list[tuple[str, dict[str, Any]]] = []
+        self.transitions = [{"id": "11", "name": "Start"}]
+
+    def list_webhooks(self) -> list[dict[str, Any]]:
+        return list(self.webhooks)
+
+    def register_webhook(
+        self,
+        url: str,
+        jql: str,
+        events: list[str] | None = None,
+        secret: str | None = None,
+    ) -> list[dict[str, Any]]:
+        self.webhooks.append(
+            {
+                "id": str(len(self.webhooks) + 1),
+                "url": url,
+                "jql": jql,
+                "events": list(events or []),
+                "secret": secret,
+            }
+        )
+        return [{"createdWebhookId": str(len(self.webhooks)), "failureReason": None}]
+
+    def get_issue(self, key: str) -> dict[str, Any]:
+        payload = self.issue_payloads.get(key)
+        if not payload:
+            payload = {"key": key, "fields": {"summary": "Auto", "labels": []}}
+            self.issue_payloads[key] = payload
+        return payload
+
+    def add_comment(self, key: str, body_adf: dict[str, Any]) -> dict[str, Any]:
+        self.comments.append((key, body_adf))
+        return {}
+
+    def list_transitions(self, key: str) -> list[dict[str, Any]]:
+        return list(self.transitions)
+
+    def transition_issue(self, key: str, transition_id: str) -> dict[str, Any]:
+        self.transition_calls.append((key, transition_id))
+        return {}
+
+    def update_issue_fields(self, key: str, fields: dict[str, Any]) -> dict[str, Any]:
+        self.updated_fields.append((key, fields))
+        payload = self.issue_payloads.setdefault(
+            key, {"key": key, "fields": {"summary": "", "labels": []}}
+        )
+        payload.setdefault("fields", {})["labels"] = list(fields.get("labels", []))
+        return {}
+
+
+@pytest.fixture()
+def orchestrator_test_app(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JIRA_BASE_URL", "http://mock-jira:9000")
+    monkeypatch.setenv("JIRA_TOKEN", "unit-token")
+    monkeypatch.setenv("WEBHOOK_SECRET", "unit-secret")
+    monkeypatch.setenv("ORCHESTRATOR_BASE_URL", "http://orchestrator:7010")
+    monkeypatch.setenv("AUTO_REGISTER_WEBHOOK", "1")
+    module = importlib.reload(orchestrator_module)
+    adapter = DummyAdapter()
+    original_adapter = module.adapter
+    module.adapter = adapter
+    module.LEDGER.clear()
+    module.SUGGESTIONS.clear()
+    with TestClient(module.app) as client:
+        yield client, module, adapter
+    module.adapter = original_adapter
+    module.LEDGER.clear()
+    module.SUGGESTIONS.clear()
+
+
+def test_startup_registers_webhook(orchestrator_test_app):
+    _, module, adapter = orchestrator_test_app
+    assert adapter.webhooks
+    registration = adapter.webhooks[0]
+    assert registration["url"].endswith("/webhooks/jira")
+    assert set(registration["events"]) == set(module.WEBHOOK_EVENTS)
+    assert registration["jql"] == module.WEBHOOK_JQL
+
+
+def test_ingest_saves_suggestions(orchestrator_test_app):
+    client, module, _ = orchestrator_test_app
+    issue = {"key": "SUP-1", "fields": {"summary": "Potrebujeme info"}}
+    response = client.post("/v1/jira/ingest", json={"issue": issue})
+    assert response.status_code == 200
+    suggestion = response.json()
+    assert module.SUGGESTIONS["SUP-1"]["actions"] == suggestion["actions"]
+    lookup = client.get("/v1/suggestions/SUP-1")
+    assert lookup.status_code == 200
+    assert lookup.json()["playbook_id"] == "jira-default"
+
+
+def test_webhook_triggers_auto_ingest(orchestrator_test_app):
+    client, module, adapter = orchestrator_test_app
+    adapter.issue_payloads["SUP-2"] = {"key": "SUP-2", "fields": {"summary": "Login nejde", "labels": []}}
+    payload = {"issue": {"key": "SUP-2"}}
+    body = json.dumps(payload).encode("utf-8")
+    signature = hashlib.sha256(module.WEBHOOK_SECRET.encode("utf-8") + body).hexdigest()
+    resp = client.post(
+        "/webhooks/jira",
+        data=body,
+        headers={
+            "content-type": "application/json",
+            "x-mockjira-signature": f"sha256={signature}",
+        },
+    )
+    assert resp.status_code == 200
+    assert "SUP-2" in module.SUGGESTIONS
+    assert module.SUGGESTIONS["SUP-2"]["actions"]
+
+
+def test_apply_executes_full_plan(orchestrator_test_app):
+    client, module, adapter = orchestrator_test_app
+    adapter.issue_payloads["SUP-3"] = {"key": "SUP-3", "fields": {"summary": "Potrebujem podporu", "labels": []}}
+    issue = {"key": "SUP-3", "fields": {"summary": "Potrebujem podporu"}}
+    ingest_response = client.post("/v1/jira/ingest", json={"issue": issue})
+    draft = ingest_response.json()["draft_reply_adf"]
+    apply_payload = {
+        "issueKey": "SUP-3",
+        "accepted_action_ids": ["reply-1", "transition-1", "label-1"],
+        "draft_reply_adf": draft,
+        "playbook_id": "jira-default",
+    }
+    apply_response = client.post("/v1/jira/apply", json=apply_payload)
+    assert apply_response.status_code == 200
+    assert adapter.comments and adapter.comments[0][0] == "SUP-3"
+    assert adapter.transition_calls and adapter.transition_calls[0][0] == "SUP-3"
+    assert adapter.updated_fields and adapter.updated_fields[0][1]["labels"] == ["needs-info"]
+    assert module.LEDGER["SUP-3"]["credit"] > 0


### PR DESCRIPTION
## Summary
- auto-register the orchestrator webhook on startup, surface a health endpoint and log registration outcomes
- funnel Jira webhook deliveries into ingest(), cache suggestions and expose a GET endpoint while applying labels via real field updates
- extend the Python adapter and docker-compose healthchecks plus add focused FastAPI tests for the closed loop

## Testing
- PYTHONPATH=. pytest tests/test_orchestrator_app.py


------
https://chatgpt.com/codex/tasks/task_e_68cbaf2dc9a083309cc6afa3bf6bc59b