### PR TITLE
Implement Forge panel apply flow and orchestrator contract

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - JIRA_BASE_URL=http://mock-jira:9000
       - JIRA_TOKEN=mock-token
       - WEBHOOK_SECRET=dev-secret
+      - ORCH_SECRET=forge-dev-secret
       - LEDGER_BACKEND=memory
       - SIGNATURE_VERSION=2
       - ORCHESTRATOR_BASE_URL=http://orchestrator:7010

--- a/docs/forge_demo_runbook.md
+++ b/docs/forge_demo_runbook.md
@@ -1,0 +1,69 @@
+# Digital Spiral Forge Demo Runbook
+
+This runbook demonstrates the end-to-end flow for the Digital Spiral orchestrator with the Forge issue panel. It assumes you are working from the repository root inside the devcontainer.
+
+## 1. Start mock Jira and the orchestrator
+
+```bash
+export MOCK_JIRA_SEED_CONFIG=scripts/seed_profiles/forge_demo.json
+docker compose up --build mock-jira mock-jira-seed orchestrator
+```
+
+The seed profile provisions:
+
+- one software project with two boards and eight sprints (six closed, one active, one future),
+- about ninety software issues with realistic comments and transitions,
+- a support/service desk project with ~18 tickets to exercise customer workflows.
+
+Wait for the health checks to report healthy containers before proceeding.
+
+## 2. Capture orchestrator connection details
+
+The orchestrator container exposes the API on http://localhost:7010. Note the secret and base URL you will configure in Forge:
+
+- `ORCH_URL`: `http://localhost:7010`
+- `ORCH_SECRET`: value of the `ORCH_SECRET` environment variable you passed to the container (defaults to `forge-dev-secret` in docker-compose).
+
+## 3. Deploy the Forge app
+
+1. Install dependencies if necessary: `npm install --prefix forge-app`.
+2. Log in to the Atlassian CLI: `forge login`.
+3. Register the app (first time only): `forge register`.
+4. Deploy: `forge deploy`.
+5. Install the app into your test Jira site: `forge install` (choose the site and scope).
+
+## 4. Configure the project settings page
+
+1. Open any software project in the Jira sandbox where the app is installed.
+2. Navigate to **Project settings → Apps → Digital Spiral Settings**.
+3. Enter the following values:
+   - **Orchestrator URL**: `http://localhost:7010`
+   - **Shared secret**: the value from step 2
+   - **Tenant identifier**: optional string (for example `demo-tenant`) used for ledger separation.
+4. Save the configuration.
+
+## 5. Use the issue panel
+
+1. Open an issue that belongs to the active sprint (for example `DEV1-5`).
+2. The Digital Spiral panel loads proposals from `GET /v1/jira/ingest` and displays comment, transition and label suggestions together with the estimated time savings.
+3. Click **Explain** to view the reasoning for any proposal.
+4. Click **Apply** on the comment suggestion. The button triggers `POST /v1/jira/apply` with an idempotency key and refreshes the proposal list after the orchestrator completes the Jira mutation.
+5. Confirm the issue was updated (new comment or label) in the main Jira view.
+
+## 6. Observe orchestrator ledger output
+
+Query the ledger endpoint to verify the credit attribution and audit metadata:
+
+```bash
+curl -H "X-DS-Secret: $ORCH_SECRET" "http://localhost:7010/v1/ledger?issueKey=DEV1-5"
+```
+
+The response includes the history of applied actions, credit in seconds and the last webhook payload processed for the issue.
+
+## 7. Optional follow-up checks
+
+- Inspect structured UI data: `curl -H "X-DS-Secret: $ORCH_SECRET" "http://localhost:7010/v1/jira/ingest?issueKey=DEV1-5"`.
+- Verify idempotency by repeating the `Apply` action in the panel—the orchestrator replays the cached result and does not create duplicate comments.
+- Review the HTML ledger dashboard at http://localhost:7010/ui for a quick overview of credit accumulation.
+
+This workflow can be recorded as a short screen capture (60–90 seconds) to demonstrate the proposal → apply → ledger feedback loop end to end.

--- a/forge-app/manifest.yml
+++ b/forge-app/manifest.yml
@@ -1,39 +1,25 @@
 modules:
-  jira:issueGlance:
-    - key: ds-issue-glance
-      title: Digital Spiral
-      icon: https://developer.atlassian.com/platform/forge/images/icons/issue-glance-icon.svg
-      render: native
-      resolver:
-        function: glance-resolver
-
   jira:issuePanel:
     - key: ds-issue-panel
       title: Digital Spiral
+      icon: https://developer.atlassian.com/platform/forge/images/icons/issue-panel-icon.svg
+      render: native
       resolver:
-        function: panel-resolver
-      viewportSize: medium
-
-  jira:issueAction:
-    - key: ds-apply-action
-      title: Apply suggestions
-      resolver:
-        function: apply-resolver
+        function: panel-run
 
   jira:projectSettingsPage:
     - key: ds-settings
       title: Digital Spiral Settings
+      render: native
       resolver:
-        function: settings-resolver
+        function: settings-run
 
 function:
-  - key: glance-resolver
-    handler: src/glance.run
-  - key: panel-resolver
+  - key: panel-run
     handler: src/panel.run
-  - key: apply-resolver
+  - key: apply-run
     handler: src/apply.run
-  - key: settings-resolver
+  - key: settings-run
     handler: src/settings.run
 
 permissions:
@@ -41,19 +27,13 @@ permissions:
     - read:jira-work
     - write:jira-work
     - read:jira-user
-    - read:issue-details:jira
-    - write:issue:jira
-    - manage:issue-link:jira
-    - read:comment:jira
-    - write:comment:jira
+    - manage:jira-project
   external:
     fetch:
       backend:
-        - '*.ngrok.io'
-        - '*.yourdomain.tld'
+        - ${ORCH_URL}
+
 app:
+  id: ari:cloud:ecosystem::app/00000000-0000-0000-0000-000000000000
   runtime:
     snapshots: false
-
-resources:
-  - key: DS_ORCH_URL

--- a/forge-app/src/apply.ts
+++ b/forge-app/src/apply.ts
@@ -1,60 +1,24 @@
 import type { ProjectConfig } from './lib/config';
 import { getProjectConfig } from './lib/config';
-import { applyPlan } from './lib/orchestrator';
-import { addComment, transition, addLabel } from './lib/jira';
+import type { Proposal } from './lib/orchestrator';
+import { applyAction } from './lib/orchestrator';
 
-type ForgeStep =
-  | { kind: 'jira.add_comment'; args: { issueKey: string; bodyAdf: any } }
-  | { kind: 'jira.transition'; args: { issueKey: string; transitionId: string } }
-  | { kind: 'jira.add_label'; args: { issueKey: string; value: string } }
-  | { kind: 'jira.create_linked_issue'; args: { projectKey: string; summary: string; linkType?: string } };
-
-type ApplyInput = {
+export type ApplyInput = {
   issueKey: string;
-  accepted_action_ids: string[];
-  draft_reply_adf: any;
-  playbook_id?: string;
+  action: Proposal;
 };
 
-async function performStep(step: ForgeStep) {
-  if (step.kind === 'jira.add_comment') {
-    await addComment(step.args.issueKey, step.args.bodyAdf);
-  } else if (step.kind === 'jira.transition') {
-    await transition(step.args.issueKey, step.args.transitionId);
-  } else if (step.kind === 'jira.add_label') {
-    await addLabel(step.args.issueKey, step.args.value);
-  }
-  // jira.create_linked_issue intentionally left for future implementation
-}
-
-export async function executeForgePlan(cfg: ProjectConfig, payload: ApplyInput) {
-  const result = await applyPlan(cfg, payload);
-  const plan: ForgeStep[] = Array.isArray(result.forge_plan) ? result.forge_plan : [];
-
-  for (const step of plan) {
-    await performStep(step);
-  }
-
-  return {
-    ok: true,
-    applied: plan.length,
-    ledger: result.ledger_delta ?? {},
-    raw: result,
-  };
+export async function executeApply(cfg: ProjectConfig, payload: ApplyInput) {
+  return applyAction(cfg, payload.issueKey, payload.action);
 }
 
 export const run = async (event: any, context: any) => {
-  const { issueKey, accepted_action_ids, draft_reply_adf, playbook_id } = event.payload as ApplyInput;
+  const { issueKey, action } = event.payload as ApplyInput;
   const projectKey = context.platformContext.projectKey as string;
   const cfg = await getProjectConfig(projectKey);
   if (!cfg) {
     throw new Error('Digital Spiral not configured for this project.');
   }
 
-  return executeForgePlan(cfg, {
-    issueKey,
-    accepted_action_ids,
-    draft_reply_adf,
-    playbook_id,
-  });
+  return executeApply(cfg, { issueKey, action });
 };

--- a/forge-app/src/lib/config.ts
+++ b/forge-app/src/lib/config.ts
@@ -3,14 +3,31 @@ import { storage } from '@forge/api';
 export type ProjectConfig = {
   orchestratorUrl: string;
   secret: string;
-  playbookId?: string;
+  tenantId?: string;
 };
 
 const configKey = (projectKey: string) => `ds/config/${projectKey}`;
 
+function configFromEnv(): ProjectConfig | null {
+  const url = process.env.ORCH_URL;
+  const secret = process.env.ORCH_SECRET;
+  if (!url || !secret) {
+    return null;
+  }
+  const tenantId = process.env.TENANT_ID;
+  return {
+    orchestratorUrl: url,
+    secret,
+    tenantId: tenantId || undefined,
+  };
+}
+
 export async function getProjectConfig(projectKey: string): Promise<ProjectConfig | null> {
-  const value = await storage.get(configKey(projectKey));
-  return (value as ProjectConfig) ?? null;
+  const value = (await storage.get(configKey(projectKey))) as ProjectConfig | undefined;
+  if (value && value.orchestratorUrl && value.secret) {
+    return value;
+  }
+  return configFromEnv();
 }
 
 export async function setProjectConfig(projectKey: string, cfg: ProjectConfig) {

--- a/forge-app/src/panel.tsx
+++ b/forge-app/src/panel.tsx
@@ -1,133 +1,256 @@
 import {
   IssuePanel,
-  Form,
-  CheckboxGroup,
-  Checkbox,
   SectionMessage,
   useProductContext,
   useState,
   Button,
+  Text,
+  Strong,
+  ButtonSet,
   render,
 } from '@forge/ui';
-import { requestJira } from '@forge/api';
-import { getProjectConfig } from './lib/config';
-import { getSuggestions, ingest } from './lib/orchestrator';
-import { executeForgePlan } from './apply';
+import { getProjectConfig, type ProjectConfig } from './lib/config';
+import {
+  applyAction,
+  fetchProposals,
+  type ApplyResponse,
+  type IngestResponse,
+  type Proposal,
+} from './lib/orchestrator';
+
+type ReadyState = {
+  status: 'ready';
+  cfg: ProjectConfig;
+  issueKey: string;
+  proposals: Proposal[];
+  ledgerHint?: IngestResponse['estimated_savings'];
+  applyingId: string | null;
+  explainingId: string | null;
+  lastResult: ApplyResponse | null;
+};
+
+type ErrorState = {
+  status: 'error';
+  message: string;
+};
+
+type PanelState = ReadyState | ErrorState;
+
+function proposalTitle(proposal: Proposal): string {
+  if (proposal.kind === 'comment') {
+    return 'Add comment';
+  }
+  if (proposal.kind === 'transition') {
+    return `Transition to ${proposal.transitionName || proposal.transitionId}`;
+  }
+  if (proposal.kind === 'set-labels') {
+    return 'Update labels';
+  }
+  if (proposal.kind === 'link') {
+    return 'Create link';
+  }
+  return proposal.id;
+}
+
+function extractPlainText(node: any): string {
+  if (!node) {
+    return '';
+  }
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractPlainText).join(' ');
+  }
+  if (typeof node === 'object' && node) {
+    if (typeof node.text === 'string') {
+      return node.text;
+    }
+    if (Array.isArray(node.content)) {
+      return extractPlainText(node.content);
+    }
+  }
+  return '';
+}
 
 const Panel = () => {
   const { platformContext } = useProductContext();
-  const issueKey = platformContext?.issueKey as string;
-  const projectKey = platformContext?.projectKey as string;
+  const issueKey = platformContext?.issueKey as string | undefined;
+  const projectKey = platformContext?.projectKey as string | undefined;
 
-  const [state, setState] = useState(async () => {
+  const [state, setState] = useState<PanelState>(async () => {
+    if (!issueKey || !projectKey) {
+      return { status: 'error', message: 'Missing Jira context.' };
+    }
     const cfg = await getProjectConfig(projectKey);
     if (!cfg) {
-      return { error: 'Configure orchestrator in Project Settings first.' } as const;
+      return {
+        status: 'error',
+        message: 'Configure orchestrator in Project Settings first.',
+      };
     }
-
-    const res = await requestJira(`/rest/api/3/issue/${issueKey}?fields=summary,description`);
-    if (!res.ok) {
-      return { error: `Failed to load issue: ${res.status}` } as const;
+    try {
+      const data = await fetchProposals(cfg, issueKey);
+      return {
+        status: 'ready',
+        cfg,
+        issueKey,
+        proposals: data.proposals || [],
+        ledgerHint: data.estimated_savings,
+        applyingId: null,
+        explainingId: null,
+        lastResult: null,
+      };
+    } catch (err: any) {
+      return {
+        status: 'error',
+        message: err?.message || 'Failed to load proposals from orchestrator.',
+      };
     }
-    const issue = await res.json();
-
-    let suggestions = await getSuggestions(cfg, issueKey);
-    if (!suggestions || !suggestions.actions) {
-      try {
-        suggestions = await ingest(cfg, {
-          key: issueKey,
-          fields: issue.fields,
-          project: { key: projectKey },
-        });
-      } catch (err: any) {
-        return { error: `Ingest failed: ${err.message}` } as const;
-      }
-    }
-
-    return {
-      cfg,
-      suggestions,
-      lastResult: null,
-    } as const;
   });
 
-  if ('error' in state) {
+  const refresh = async () => {
+    if (state.status !== 'ready') {
+      return;
+    }
+    try {
+      const data = await fetchProposals(state.cfg, state.issueKey);
+      setState({
+        ...state,
+        proposals: data.proposals || [],
+        ledgerHint: data.estimated_savings,
+        applyingId: null,
+        lastResult: null,
+      });
+    } catch (err: any) {
+      setState({
+        status: 'error',
+        message: err?.message || 'Failed to refresh proposals.',
+      });
+    }
+  };
+
+  const applyProposal = async (proposal: Proposal) => {
+    if (state.status !== 'ready') {
+      return;
+    }
+    setState({ ...state, applyingId: proposal.id });
+    try {
+      const result = await applyAction(state.cfg, state.issueKey, proposal);
+      const data = await fetchProposals(state.cfg, state.issueKey);
+      setState({
+        status: 'ready',
+        cfg: state.cfg,
+        issueKey: state.issueKey,
+        proposals: data.proposals || [],
+        ledgerHint: data.estimated_savings,
+        applyingId: null,
+        explainingId: state.explainingId,
+        lastResult: result,
+      });
+    } catch (err: any) {
+      setState({
+        status: 'error',
+        message: err?.message || 'Apply failed.',
+      });
+    }
+  };
+
+  const toggleExplain = (proposalId: string) => {
+    if (state.status !== 'ready') {
+      return;
+    }
+    setState({
+      ...state,
+      explainingId: state.explainingId === proposalId ? null : proposalId,
+    });
+  };
+
+  if (state.status === 'error') {
     return (
       <IssuePanel>
         <SectionMessage appearance="error" title="Digital Spiral">
-          {state.error}
+          {state.message}
         </SectionMessage>
       </IssuePanel>
     );
   }
 
-  const submit = async (formData: { actions: string[] }) => {
-    const payload = {
-      issueKey,
-      accepted_action_ids: formData.actions || [],
-      draft_reply_adf: state.suggestions?.draft_reply_adf,
-      playbook_id: state.suggestions?.playbook_id,
-    };
-
-    const result = await executeForgePlan(state.cfg, payload);
-    setState({ ...state, lastResult: result });
-
-    return result;
-  };
-
-  const refresh = async () => {
-    setState(async () => {
-      const cfg = await getProjectConfig(projectKey);
-      if (!cfg) {
-        return { error: 'Configure orchestrator in Project Settings first.' } as const;
-      }
-      const res = await requestJira(`/rest/api/3/issue/${issueKey}?fields=summary,description`);
-      if (!res.ok) {
-        return { error: `Failed to load issue: ${res.status}` } as const;
-      }
-      try {
-        const suggestions = await ingest(cfg, {
-          key: issueKey,
-          fields: (await res.json()).fields,
-          project: { key: projectKey },
-        });
-        return {
-          cfg,
-          suggestions,
-          lastResult: null,
-        } as const;
-      } catch (err: any) {
-        return { error: `Ingest failed: ${err.message}` } as const;
-      }
-    });
-  };
-
   return (
     <IssuePanel>
-      {Array.isArray(state.suggestions?.actions) && state.suggestions.actions.length > 0 ? (
-        <Form onSubmit={submit} submitButtonText="Apply">
-          <CheckboxGroup label="Planned actions" name="actions">
-            {state.suggestions.actions.map((action: any) => (
-              <Checkbox
-                key={action.id}
-                value={action.id}
-                label={action.type || action.summary || action.id}
-                defaultChecked
-              />
-            ))}
-          </CheckboxGroup>
-        </Form>
-      ) : (
-        <SectionMessage title="Digital Spiral" appearance="warning">
-          No actions received from orchestrator.
-        </SectionMessage>
-      )}
-      {state.lastResult ? (
-        <SectionMessage title="Applied" appearance="confirmation">
-          Applied {state.lastResult.applied} action(s).
+      {state.ledgerHint?.seconds ? (
+        <SectionMessage appearance="information" title="Estimated savings">
+          <Text>
+            Potential time saved: <Strong>{state.ledgerHint.seconds}</Strong> seconds.
+          </Text>
         </SectionMessage>
       ) : null}
-      <Button text="Regenerate" onClick={refresh} />
+      {state.lastResult?.ok ? (
+        <SectionMessage appearance="confirmation" title="Applied">
+          <Text>
+            Applied action <Strong>{state.lastResult.applied?.id}</Strong>
+            {state.lastResult.credit?.seconds
+              ? ` · credited ${state.lastResult.credit.seconds} seconds`
+              : ''}
+            .
+          </Text>
+        </SectionMessage>
+      ) : null}
+      {state.proposals.length === 0 ? (
+        <SectionMessage appearance="warning" title="Digital Spiral">
+          No proposals available for this issue. Try refreshing.
+        </SectionMessage>
+      ) : (
+        state.proposals.map((proposal) => {
+          const commentPreview =
+            proposal.kind === 'comment' && proposal.body_adf
+              ? extractPlainText(proposal.body_adf).slice(0, 280)
+              : '';
+          return (
+            <SectionMessage key={proposal.id} title={proposalTitle(proposal)} appearance="information">
+              {proposal.kind === 'comment' && commentPreview ? (
+                <Text>
+                  Draft reply preview: <Strong>{commentPreview}</Strong>
+                </Text>
+              ) : null}
+              {proposal.kind === 'transition' && proposal.transitionId ? (
+                <Text>
+                  Transition ID: <Strong>{proposal.transitionId}</Strong>
+                </Text>
+              ) : null}
+              {proposal.kind === 'set-labels' && proposal.labels ? (
+                <Text>
+                  Labels: <Strong>{proposal.labels.join(', ')}</Strong>{' '}
+                  ({proposal.mode || 'merge'})
+                </Text>
+              ) : null}
+              {proposal.kind === 'link' && proposal.url ? (
+                <Text>
+                  Link to <Strong>{proposal.title || proposal.url}</Strong>
+                </Text>
+              ) : null}
+              {state.explainingId === proposal.id && proposal.explain ? (
+                <Text>{proposal.explain}</Text>
+              ) : null}
+              <ButtonSet>
+                <Button
+                  text={state.applyingId === proposal.id ? 'Applying…' : 'Apply'}
+                  onClick={() => applyProposal(proposal)}
+                  isDisabled={state.applyingId !== null && state.applyingId !== proposal.id}
+                />
+                {proposal.explain ? (
+                  <Button
+                    text={state.explainingId === proposal.id ? 'Hide explanation' : 'Explain'}
+                    appearance="subtle"
+                    onClick={() => toggleExplain(proposal.id)}
+                  />
+                ) : null}
+              </ButtonSet>
+            </SectionMessage>
+          );
+        })
+      )}
+      <Button text="Refresh proposals" onClick={refresh} />
     </IssuePanel>
   );
 };

--- a/forge-app/src/settings.tsx
+++ b/forge-app/src/settings.tsx
@@ -15,13 +15,20 @@ const Settings = () => {
 
   const [config] = useState(async () => {
     const stored = await getProjectConfig(projectKey);
-    return stored ?? { orchestratorUrl: '', secret: '' };
+    return (
+      stored ?? {
+        orchestratorUrl: '',
+        secret: '',
+        tenantId: '',
+      }
+    );
   });
 
-  const onSubmit = async (data: { orchestratorUrl: string; secret: string }) => {
+  const onSubmit = async (data: { orchestratorUrl: string; secret: string; tenantId?: string }) => {
     await setProjectConfig(projectKey, {
-      orchestratorUrl: data.orchestratorUrl,
-      secret: data.secret,
+      orchestratorUrl: data.orchestratorUrl?.trim() ?? '',
+      secret: data.secret?.trim() ?? '',
+      tenantId: data.tenantId?.trim() ? data.tenantId.trim() : undefined,
     });
     return true;
   };
@@ -34,6 +41,12 @@ const Settings = () => {
       <Form onSubmit={onSubmit} submitButtonText="Save">
         <TextField name="orchestratorUrl" label="Orchestrator URL" defaultValue={config.orchestratorUrl} />
         <TextField name="secret" label="Shared secret" defaultValue={config.secret} />
+        <TextField
+          name="tenantId"
+          label="Tenant identifier (optional)"
+          defaultValue={config.tenantId}
+          description="Used to scope orchestrator storage and allowlist entries."
+        />
       </Form>
     </ProjectSettingsPage>
   );

--- a/scripts/seed_profiles/forge_demo.json
+++ b/scripts/seed_profiles/forge_demo.json
@@ -1,0 +1,17 @@
+{
+  "description": "Forge demo dataset with one software project, support queue and rich sprint history for Digital Spiral walkthroughs.",
+  "generator": {
+    "seed": 20240927,
+    "days": 180,
+    "software_projects": 1,
+    "servicedesk_projects": 1,
+    "issues_per_project": 95,
+    "boards_per_sw_project": 2,
+    "sprints_per_board": 8,
+    "sprint_length_days": 14,
+    "comments_per_issue_avg": 2.4,
+    "transition_rate": 0.82,
+    "link_probability": 0.3,
+    "assignee_churn_prob": 0.35
+  }
+}

--- a/tests/test_orchestrator_app.py
+++ b/tests/test_orchestrator_app.py
@@ -73,6 +73,7 @@ def orchestrator_test_app(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("JIRA_BASE_URL", "http://mock-jira:9000")
     monkeypatch.setenv("JIRA_TOKEN", "unit-token")
     monkeypatch.setenv("WEBHOOK_SECRET", "unit-secret")
+    monkeypatch.setenv("ORCH_SECRET", "unit-shared-secret")
     monkeypatch.setenv("ORCHESTRATOR_BASE_URL", "http://orchestrator:7010")
     monkeypatch.setenv("AUTO_REGISTER_WEBHOOK", "1")
     module = importlib.reload(orchestrator_module)
@@ -81,11 +82,13 @@ def orchestrator_test_app(monkeypatch: pytest.MonkeyPatch):
     module.adapter = adapter
     module.LEDGER.clear()
     module.SUGGESTIONS.clear()
+    module.APPLY_RESULTS.clear()
     with TestClient(module.app) as client:
         yield client, module, adapter
     module.adapter = original_adapter
     module.LEDGER.clear()
     module.SUGGESTIONS.clear()
+    module.APPLY_RESULTS.clear()
 
 
 def test_startup_registers_webhook(orchestrator_test_app):
@@ -97,16 +100,24 @@ def test_startup_registers_webhook(orchestrator_test_app):
     assert registration["jql"] == module.WEBHOOK_JQL
 
 
-def test_ingest_saves_suggestions(orchestrator_test_app):
-    client, module, _ = orchestrator_test_app
-    issue = {"key": "SUP-1", "fields": {"summary": "Potrebujeme info"}}
-    response = client.post("/v1/jira/ingest", json={"issue": issue})
+def test_ingest_returns_proposals(orchestrator_test_app):
+    client, module, adapter = orchestrator_test_app
+    adapter.issue_payloads["SUP-1"] = {
+        "key": "SUP-1",
+        "fields": {"summary": "Potrebujeme info", "labels": []},
+    }
+    response = client.get(
+        "/v1/jira/ingest",
+        params={"issueKey": "SUP-1"},
+        headers={"x-ds-secret": "unit-shared-secret"},
+    )
     assert response.status_code == 200
-    suggestion = response.json()
-    assert module.SUGGESTIONS["SUP-1"]["actions"] == suggestion["actions"]
-    lookup = client.get("/v1/suggestions/SUP-1")
-    assert lookup.status_code == 200
-    assert lookup.json()["playbook_id"] == "jira-default"
+    payload = response.json()
+    assert payload["issueKey"] == "SUP-1"
+    assert module.SUGGESTIONS["SUP-1"]["proposals"] == payload["proposals"]
+    assert any(p["kind"] == "comment" for p in payload["proposals"])
+    ledger_entry = module.LEDGER["SUP-1"]
+    assert ledger_entry["estimated_savings"]["seconds"] == module.DEFAULT_ESTIMATED_SAVINGS_SECONDS
 
 
 def test_webhook_triggers_auto_ingest(orchestrator_test_app):
@@ -125,24 +136,58 @@ def test_webhook_triggers_auto_ingest(orchestrator_test_app):
     )
     assert resp.status_code == 200
     assert "SUP-2" in module.SUGGESTIONS
-    assert module.SUGGESTIONS["SUP-2"]["actions"]
+    assert module.SUGGESTIONS["SUP-2"]["proposals"]
+    assert module.LEDGER["SUP-2"]["last_event"] == payload
 
 
 def test_apply_executes_full_plan(orchestrator_test_app):
     client, module, adapter = orchestrator_test_app
-    adapter.issue_payloads["SUP-3"] = {"key": "SUP-3", "fields": {"summary": "Potrebujem podporu", "labels": []}}
-    issue = {"key": "SUP-3", "fields": {"summary": "Potrebujem podporu"}}
-    ingest_response = client.post("/v1/jira/ingest", json={"issue": issue})
-    draft = ingest_response.json()["draft_reply_adf"]
-    apply_payload = {
-        "issueKey": "SUP-3",
-        "accepted_action_ids": ["reply-1", "transition-1", "label-1"],
-        "draft_reply_adf": draft,
-        "playbook_id": "jira-default",
+    adapter.issue_payloads["SUP-3"] = {
+        "key": "SUP-3",
+        "fields": {"summary": "Potrebujem podporu", "labels": []},
     }
-    apply_response = client.post("/v1/jira/apply", json=apply_payload)
+    ingest_response = client.get(
+        "/v1/jira/ingest",
+        params={"issueKey": "SUP-3"},
+        headers={"x-ds-secret": "unit-shared-secret"},
+    )
+    proposals = ingest_response.json()["proposals"]
+    comment_action = next(p for p in proposals if p["kind"] == "comment")
+    label_action = next(p for p in proposals if p["kind"] == "set-labels")
+
+    apply_response = client.post(
+        "/v1/jira/apply",
+        json={"issueKey": "SUP-3", "action": comment_action},
+        headers={
+            "x-ds-secret": "unit-shared-secret",
+            "Idempotency-Key": f"SUP-3:{comment_action['id']}",
+        },
+    )
     assert apply_response.status_code == 200
+    result = apply_response.json()
+    assert result["ok"] is True
     assert adapter.comments and adapter.comments[0][0] == "SUP-3"
-    assert adapter.transition_calls and adapter.transition_calls[0][0] == "SUP-3"
-    assert adapter.updated_fields and adapter.updated_fields[0][1]["labels"] == ["needs-info"]
-    assert module.LEDGER["SUP-3"]["credit"] > 0
+
+    second_call = client.post(
+        "/v1/jira/apply",
+        json={"issueKey": "SUP-3", "action": comment_action},
+        headers={
+            "x-ds-secret": "unit-shared-secret",
+            "Idempotency-Key": f"SUP-3:{comment_action['id']}",
+        },
+    )
+    assert second_call.status_code == 200
+    assert len(adapter.comments) == 1
+
+    apply_labels = client.post(
+        "/v1/jira/apply",
+        json={"issueKey": "SUP-3", "action": label_action},
+        headers={
+            "x-ds-secret": "unit-shared-secret",
+            "Idempotency-Key": f"SUP-3:{label_action['id']}",
+        },
+    )
+    assert apply_labels.status_code == 200
+    assert adapter.updated_fields and adapter.updated_fields[0][1]["labels"]
+    ledger_entry = module.LEDGER["SUP-3"]
+    assert ledger_entry["total_credit_seconds"] > 0


### PR DESCRIPTION
## Summary
- connect the Forge issue panel and settings UI to the orchestrator ingest/apply APIs with tenant-aware configuration
- overhaul the orchestrator Jira endpoints to expose uniform proposals, secure idempotent apply execution and richer ledger data
- document the end-to-end demo via a forge-specific seed profile, runbook and compose secret

## Testing
- `PYTHONPATH=. pytest tests/test_orchestrator_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ccef006e5c833081d4dbfede694cf8