### PR TITLE
Implement credit ledger integration and Forge credit UI

### DIFF
--- a/forge-app/src/glance.tsx
+++ b/forge-app/src/glance.tsx
@@ -1,12 +1,70 @@
-import { IssueGlance, Text, useProductContext, render } from '@forge/ui';
+import { IssueGlance, Text, useProductContext, render, useState } from '@forge/ui';
+import { getProjectConfig } from './lib/config';
+import { fetchIssueCredit } from './lib/orchestrator';
+
+const SPRINT_WINDOW_DAYS = 14;
+
+type GlanceState = {
+  label: string;
+  value: string;
+};
+
+function sprintSince(): string {
+  const windowMs = SPRINT_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  return new Date(Date.now() - windowMs).toISOString();
+}
+
+function resolveActor(platformContext: any): { id?: string; display?: string } {
+  const accountId =
+    (platformContext as any)?.accountId ??
+    (platformContext as any)?.userAccountId ??
+    (platformContext as any)?.localId ??
+    null;
+  const id = accountId ? `human.${accountId}` : undefined;
+  const display = (platformContext as any)?.displayName ?? undefined;
+  return { id: id ?? undefined, display };
+}
 
 const Glance = () => {
   const { platformContext } = useProductContext();
   const issueKey = platformContext?.issueKey as string | undefined;
+  const projectKey = platformContext?.projectKey as string | undefined;
+
+  const [state] = useState<GlanceState>(async () => {
+    if (!issueKey || !projectKey) {
+      return { label: 'Digital Spiral', value: 'No issue context' };
+    }
+    const cfg = await getProjectConfig(projectKey);
+    if (!cfg) {
+      return { label: 'Digital Spiral', value: 'Configure orchestrator' };
+    }
+    const actor = resolveActor(platformContext);
+    try {
+      const credit = await fetchIssueCredit(cfg, issueKey, {
+        actorId: actor.id,
+        actorDisplay: actor.display,
+        since: sprintSince(),
+        limit: 3,
+      });
+      const windowSeconds =
+        typeof credit.windowSecondsSaved === 'number'
+          ? credit.windowSecondsSaved
+          : credit.totalSecondsSaved;
+      const rounded = Math.max(Math.round(windowSeconds), 0);
+      return {
+        label: 'Saved this sprint',
+        value: `−${rounded}s`,
+      };
+    } catch (err) {
+      return { label: 'Digital Spiral', value: 'No credit yet' };
+    }
+  });
 
   return (
     <IssueGlance>
-      <Text>Digital Spiral: Suggestions ready{issueKey ? ` for ${issueKey}` : ''}</Text>
+      <Text>
+        {state.label}: {state.value}
+      </Text>
     </IssueGlance>
   );
 };

--- a/forge-app/src/lib/config.ts
+++ b/forge-app/src/lib/config.ts
@@ -4,6 +4,7 @@ export type ProjectConfig = {
   orchestratorUrl: string;
   secret: string;
   tenantId?: string;
+  token?: string;
 };
 
 const configKey = (projectKey: string) => `ds/config/${projectKey}`;
@@ -11,6 +12,7 @@ const configKey = (projectKey: string) => `ds/config/${projectKey}`;
 function configFromEnv(): ProjectConfig | null {
   const url = process.env.ORCH_URL;
   const secret = process.env.ORCH_SECRET;
+  const token = process.env.ORCH_TOKEN;
   if (!url || !secret) {
     return null;
   }
@@ -19,6 +21,7 @@ function configFromEnv(): ProjectConfig | null {
     orchestratorUrl: url,
     secret,
     tenantId: tenantId || undefined,
+    token: token || undefined,
   };
 }
 

--- a/forge-app/src/panel.tsx
+++ b/forge-app/src/panel.tsx
@@ -121,9 +121,17 @@ function describeCredit(credit: CreditInfo | null | undefined, actorId?: string 
     return '';
   }
   const seconds = Math.round(credit.secondsSaved);
-  const detail = formatEventSplits(credit.splits, actorId, seconds);
-  const base = `−${seconds}s credited`;
-  return detail ? `${base} (${detail})` : base;
+  const splits = credit.splits || [];
+  if (!splits.length) {
+    return `−${seconds}s`;
+  }
+  const detail = splits
+    .map((split) => {
+      const shareSeconds = Math.round(seconds * split.weight);
+      return `${participantLabel(split.id, actorId)} ${shareSeconds}s`;
+    })
+    .join(' / ');
+  return `−${seconds}s (${detail})`;
 }
 
 function formatSplitPercent(weight: number): string {

--- a/orchestrator/metrics.py
+++ b/orchestrator/metrics.py
@@ -11,24 +11,29 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 _BASELINES = {
-    "comment": 90,
-    "transition": 30,
-    "set-labels": 45,
-    "link": 60,
+    "comment": 30,
+    "transition": 45,
+    "set-labels": 20,
+    "link": 25,
 }
 
 DEFAULT_SEED_PATH = Path(os.getenv("SEED_DATA_PATH", "artifacts/forge_demo_seed.json"))
 
 
-def estimate_savings(action_kind: str, context: Mapping[str, Any] | None = None) -> int:
-    """Estimate seconds saved for a given action kind."""
+def estimate_seconds(action: str, context: Mapping[str, Any] | None = None) -> int:
+    """Estimate seconds saved for a given action type."""
 
-    base = _BASELINES.get(action_kind, 30)
+    base = _BASELINES.get(action, 30)
     bundle = 1
     if context:
         bundle = int(context.get("bundle_size", 1)) or 1
-    seconds = int(base * bundle)
-    return max(seconds, 0)
+    return max(int(base * bundle), 0)
+
+
+def estimate_savings(action_kind: str, context: Mapping[str, Any] | None = None) -> int:
+    """Backward compatible wrapper for older callers."""
+
+    return estimate_seconds(action_kind, context)
 
 
 def _percentile(values: Sequence[float], percentile: float) -> float:

--- a/orchestrator/models.py
+++ b/orchestrator/models.py
@@ -1,30 +1,39 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
-
-
-class CreditSplit(BaseModel):
-    """Represents an individual participant share in a credit event."""
-
-    id: str
-    weight: float = Field(ge=0.0)
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 
 class Impact(BaseModel):
     """Captures measured impact of an action."""
 
-    secondsSaved: int = Field(ge=0)
-    quality: Optional[float] = Field(default=None)
+    secondsSaved: int = Field(
+        ge=0,
+        validation_alias=AliasChoices("secondsSaved", "seconds_saved"),
+        serialization_alias="secondsSaved",
+    )
+    quality: Optional[float] = None
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class Attribution(BaseModel):
     """Describes how credit is attributed to contributors."""
 
-    split: List[CreditSplit] = Field(default_factory=list)
-    reason: Optional[str] = None
+    agentId: str = Field(
+        validation_alias=AliasChoices("agentId", "agent_id", "id"),
+        serialization_alias="agentId",
+    )
+    weight: float = Field(ge=0.0)
+    displayName: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("displayName", "display_name"),
+        serialization_alias="displayName",
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class CreditEvent(BaseModel):
@@ -32,17 +41,62 @@ class CreditEvent(BaseModel):
 
     id: str
     ts: datetime
-    issueKey: str
-    actor: Dict[str, Any]
+    issueKey: str = Field(
+        validation_alias=AliasChoices("issueKey", "issue_key"),
+        serialization_alias="issueKey",
+    )
+    actor: Dict[str, Any] = Field(default_factory=dict)
     action: str
     inputs: Dict[str, Any] = Field(default_factory=dict)
     impact: Impact
-    attribution: Attribution
+    attributions: List[Attribution] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("attributions", "attribution"),
+        serialization_alias="attributions",
+    )
     parents: List[str] = Field(default_factory=list)
-    prev: Optional[str] = None
+    prevHash: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("prevHash", "prev", "prev_hash"),
+        serialization_alias="prevHash",
+    )
     hash: Optional[str] = None
+    attributionReason: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("attributionReason", "reason", "attribution_reason"),
+        serialization_alias="attributionReason",
+    )
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _convert_legacy(cls, values: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Accept legacy payloads that used attribution.split."""
+
+        if not isinstance(values, Mapping):  # pragma: no cover - defensive
+            return values
+        materialised = dict(values)
+        if "attribution" in materialised and "attributions" not in materialised:
+            legacy = materialised.pop("attribution")
+            if isinstance(legacy, Mapping):
+                splits = legacy.get("split") or []
+                attributions: List[Dict[str, Any]] = []
+                for item in splits:
+                    if not isinstance(item, Mapping):
+                        continue
+                    agent_id = item.get("id") or item.get("agentId")
+                    weight = item.get("weight")
+                    if agent_id is None or weight is None:
+                        continue
+                    attributions.append({"agentId": agent_id, "weight": weight})
+                if attributions:
+                    materialised["attributions"] = attributions
+                reason = legacy.get("reason") if isinstance(legacy, Mapping) else None
+                if reason and "attributionReason" not in materialised:
+                    materialised["attributionReason"] = reason
+        return materialised
 
 
 class ContributorSummary(BaseModel):
@@ -81,3 +135,15 @@ class CreditSummary(BaseModel):
     totalSecondsSaved: float
     eventCount: int
     topContributors: List[ContributorSummary] = Field(default_factory=list)
+
+
+__all__ = [
+    "AgentCreditSummary",
+    "Attribution",
+    "ContributorSummary",
+    "CreditEvent",
+    "CreditSummary",
+    "Impact",
+    "IssueCreditSummary",
+]
+

--- a/scripts/seed_profiles/forge_demo.json
+++ b/scripts/seed_profiles/forge_demo.json
@@ -1,4 +1,19 @@
 {
-  "description": "Forge demo dataset with one software project, support queue and rich sprint history for Digital Spiral walkthroughs.",
-  "seed_file": "artifacts/forge_demo_seed.json"
+  "description": "Deterministic Forge demo dataset with rich sprint history, seeded handoffs and realistic backlog aging for Digital Spiral walkthroughs.",
+  "generator": {
+    "seed": 314159,
+    "days": 180,
+    "software_projects": 1,
+    "servicedesk_projects": 1,
+    "issues_per_project": 140,
+    "boards_per_sw_project": 1,
+    "sprints_per_board": 8,
+    "sprint_length_days": 14,
+    "comments_per_issue_avg": 22.0,
+    "transition_rate": 0.82,
+    "link_probability": 0.2,
+    "assignee_churn_prob": 0.28
+  },
+  "handoff_probability": 0.2,
+  "notes": "Run: python scripts/generate_dummy_jira.py --config scripts/seed_profiles/forge_demo.json --out artifacts/forge_demo_seed.json --credit-ledger artifacts/credit-ledger.jsonl"
 }

--- a/tests/e2e/test_credit_flow.py
+++ b/tests/e2e/test_credit_flow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
+import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -8,13 +10,17 @@ from fastapi.testclient import TestClient
 from clients.python.jira_adapter import JiraAdapter
 
 
-def _auth_headers(secret: str) -> dict[str, str]:
-    return {
-        "X-DS-Secret": secret,
+def _auth_headers(secret: str, body: bytes, *, idem: str | None = None) -> dict[str, str]:
+    signature = hashlib.sha256(secret.encode("utf-8") + body).hexdigest()
+    headers = {
+        "Authorization": "Bearer e2e-token",
+        "X-Forge-Signature": f"sha256={signature}",
         "X-DS-Actor": "human.tester",
-        "Idempotency-Key": "test-key",
         "Content-Type": "application/json",
     }
+    if idem:
+        headers["Idempotency-Key"] = idem
+    return headers
 
 
 def test_apply_creates_credit_event(monkeypatch, tmp_path: Path, live_server: str) -> None:
@@ -24,6 +30,7 @@ def test_apply_creates_credit_event(monkeypatch, tmp_path: Path, live_server: st
     monkeypatch.setenv("JIRA_BASE_URL", live_server)
     monkeypatch.setenv("JIRA_TOKEN", "mock-token")
     monkeypatch.setenv("FORGE_SHARED_SECRET", secret)
+    monkeypatch.setenv("ORCHESTRATOR_TOKEN", "e2e-token")
     monkeypatch.setenv("CREDIT_LEDGER_PATH", str(ledger_path))
     monkeypatch.setenv("AUTO_REGISTER_WEBHOOK", "0")
     monkeypatch.setenv("FORGE_ALLOWLIST", "")
@@ -39,7 +46,7 @@ def test_apply_creates_credit_event(monkeypatch, tmp_path: Path, live_server: st
 
     with TestClient(app_module.app) as client:
         ingest_resp = client.get(
-            f"/v1/jira/ingest?issueKey={issue_key}", headers={"X-DS-Secret": secret}
+            f"/v1/jira/ingest?issueKey={issue_key}", headers=_auth_headers(secret, b"")
         )
         assert ingest_resp.status_code == 200
         proposals = ingest_resp.json().get("proposals", [])
@@ -47,27 +54,36 @@ def test_apply_creates_credit_event(monkeypatch, tmp_path: Path, live_server: st
         comment = next((item for item in proposals if item.get("kind") == "comment"), None)
         assert comment is not None, "comment proposal expected"
 
+        apply_body = json.dumps({"issueKey": issue_key, "action": comment}).encode("utf-8")
         apply_resp = client.post(
             "/v1/jira/apply",
-            json={"issueKey": issue_key, "action": comment},
-            headers=_auth_headers(secret),
+            data=apply_body,
+            headers=_auth_headers(secret, apply_body, idem="test-key"),
         )
         assert apply_resp.status_code == 200
         payload = apply_resp.json()
         assert payload.get("ok") is True
         credit_block = payload.get("credit")
-        assert credit_block and credit_block.get("secondsSaved")
-        splits = credit_block.get("splits", [])
-        assert len(splits) >= 1
-        assert abs(sum(split.get("weight", 0.0) for split in splits) - 1.0) < 1e-6
+        assert credit_block and credit_block.get("impact", {}).get("secondsSaved")
+        attributions = credit_block.get("attributions", [])
+        assert attributions, "attributions expected"
+        assert abs(sum(item.get("weight", 0.0) for item in attributions) - 1.0) < 1e-6
+
+        repeat_resp = client.post(
+            "/v1/jira/apply",
+            data=apply_body,
+            headers=_auth_headers(secret, apply_body, idem="test-key"),
+        )
+        assert repeat_resp.status_code == 200
+        assert repeat_resp.json()["credit"]["id"] == credit_block["id"]
 
         summary_resp = client.get(
-            f"/v1/credit/issue/{issue_key}", headers={"X-DS-Secret": secret}
+            f"/v1/credit/issue/{issue_key}", headers=_auth_headers(secret, b"")
         )
         assert summary_resp.status_code == 200
         summary = summary_resp.json()
-        assert summary.get("totalSecondsSaved") >= credit_block["secondsSaved"]
-        assert summary.get("recentEvents"), "expected recent events recorded"
+        assert summary.get("total_seconds") >= credit_block["impact"]["secondsSaved"]
+        assert summary.get("events"), "expected recent events recorded"
 
     ledger_contents = ledger_path.read_text(encoding="utf-8").strip().splitlines()
     assert ledger_contents, "ledger should contain at least one event"


### PR DESCRIPTION
## Summary
- connect the apply flow to the new credit ledger response shape and expose issue/agent aggregation endpoints
- implement idempotent hash-chained credit events plus updated models and metrics rollups
- refresh the Forge client/UI to sign requests, surface contributor credits, and show sprint savings while extending the seed dataset and tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68cd22f433208330b6e77842bdcd4777