### PR TITLE
Add Codex-themed component docs and MCP Jira guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@ mcp_jira/          # MCP integration layer (server facade + tools registry)
   server.py        # get_tool, invoke_tool, list_tools
   tools.py         # t_jira_* and other MCP tool callables; TOOL_REGISTRY
 
+📘 Detailné popisy komponentov nájdeš v:
+- `mockjira/README.md`
+- `mcp_jira/README.md`
+- `clients/python/README.md`
+
 clients/python/    # Python JiraAdapter (REST wrapper) + exceptions
   jira_adapter.py  # REST calls + retry + API groups (platform/agile/jsm)
   exceptions.py    # JiraError hierarchy
@@ -94,6 +99,24 @@ jsm.create_request       agile.list_sprints
 ### 4.3 Facade pre agentov
 
 Použi `mcp_jira.server.invoke_tool(name, args)` alebo `get_tool(name)(args)`. Na introspekciu `list_tools()` vráti názvy a `__doc__` popisy.
+
+### 4.4 Pripojenie MCP ↔️ Jira
+
+1. Skontroluj, že prostredie má nastavené premenné `JIRA_BASE_URL`, `JIRA_TOKEN` a voliteľne `JIRA_TIMEOUT`.
+2. Uisti sa, že mock server (alebo produkčná Jira) beží a je dostupná na zvolenej URL.
+3. Inicializuj MCP facade, napríklad:
+   ```python
+   from mcp_jira.server import list_tools, invoke_tool
+
+   print(list_tools())
+   issue = invoke_tool("jira.create_issue", {
+       "project_key": "SUP",
+       "issue_type_id": "10003",
+       "summary": "Ticket from MCP agent"
+   })
+   print(issue["key"])
+   ```
+4. Pri potrebe OAuth pozri `mcp_jira/oauth.py`. Detailný onboarding je v `mcp_jira/README.md`.
 
 ---
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,23 @@
+# Python Jira Adapter
+
+## Purpose
+`clients/python` delivers a thin Jira REST wrapper that agents can call directly or through Codex-generated snippets. It embodies the Codex goal of translating natural language tasks into code, providing a ready-made client that handles retries, authentication, and resource grouping.
+
+## Features
+- High-level methods for platform, agile, and service management APIs.
+- Automatic retry logic and structured exception hierarchy (`JiraError`).
+- Configurable base URL, token, timeout, and user agent fields via constructor arguments.
+
+## Quick Start
+```python
+from clients.python.jira_adapter import JiraAdapter
+
+adapter = JiraAdapter("http://localhost:9000", "mock-token")
+issue = adapter.create_issue("SUP", "10003", "Hello from Codex agent")
+print(issue["key"])
+```
+
+## Tips for Codex-Style Workflows
+- Combine this adapter with the MCP tooling to let natural language prompts choose between direct REST usage and tool invocations.
+- Keep summaries and descriptions concise—Codex-generated code tends to mirror the prompt closely.
+- Capture responses and errors to provide feedback loops for iterative prompt refinement, a technique highlighted in the Codex introduction article.

--- a/mcp_jira/README.md
+++ b/mcp_jira/README.md
@@ -1,0 +1,36 @@
+# MCP Jira Integration
+
+## Purpose
+The `mcp_jira` package exposes the mock Jira capabilities through the Model Context Protocol so that Codex-style agents can turn user prompts into actionable Jira operations. This aligns with the Codex vision of natural language instructions being executed as code against real services.
+
+## Tool Registry Highlights
+- `jira.create_issue`, `jira.get_issue`, `jira.search`
+- `jira.list_transitions`, `jira.transition_issue`, `jira.add_comment`
+- `jsm.create_request`, `agile.list_sprints`
+
+Each tool accepts a JSON payload and returns JSON responses mirroring Jira Cloud.
+
+## Connecting MCP to Jira
+1. **Configure environment variables** for the session that will load the MCP server:
+   - `JIRA_BASE_URL` – defaults to `http://localhost:9000` when using the included mock server.
+   - `JIRA_TOKEN` – defaults to `mock-token`; replace with a real API token when targeting Jira Cloud.
+   - `JIRA_TIMEOUT` – optional per-request timeout in seconds (default `10`).
+2. **Start the mock Jira server** (or ensure your Jira Cloud instance is reachable).
+3. **Load the MCP server facade** in your orchestrator:
+   ```python
+   from mcp_jira.server import list_tools, invoke_tool
+
+   available = list_tools()
+   result = invoke_tool("jira.create_issue", {
+       "project_key": "SUP",
+       "issue_type_id": "10003",
+       "summary": "Ticket from MCP agent"
+   })
+   print(result["key"])
+   ```
+4. **Handle authentication**: the server automatically adds the bearer token from `JIRA_TOKEN` to outgoing requests. For OAuth flows, see `mcp_jira.oauth` for helper routines.
+
+## Best Practices
+- Validate tool inputs before invocation to keep responses deterministic for Codex-powered workflows.
+- Respect rate limiting feedback from the mock server to mirror production Jira behavior.
+- Log tool invocations to provide traceability between natural language prompts and executed API actions.

--- a/mockjira/README.md
+++ b/mockjira/README.md
@@ -1,0 +1,20 @@
+# MockJira Service Overview
+
+## Purpose
+The `mockjira` package provides a FastAPI implementation of Jira Cloud endpoints that power the Digital Spiral workspace. It enables agents to practice the kind of natural-language-to-action workflows described in [Introducing Codex](https://openai.com/index/introducing-codex/), by giving them a deterministic API surface to automate against.
+
+## Key Capabilities
+- Implements core Jira REST resources (projects, issues, search, comments, transitions) with in-memory persistence.
+- Emulates Jira Agile and Service Management endpoints so orchestration flows can test sprint and request scenarios.
+- Supports webhook simulation and administrative reset/export helpers for reproducible demos.
+
+## Usage Notes
+1. Start the server locally:
+   ```bash
+   python -m mockjira.main --host 0.0.0.0 --port 9000
+   ```
+2. Configure clients with the provided base URL and token (`mock-token`).
+3. Interact through REST calls or via the MCP tooling described in the repository documentation.
+
+## Relation to Codex
+OpenAI Codex translates natural language instructions into working code. This mock server mirrors the downstream systems Codex-powered agents interact with—allowing them to convert task descriptions into API calls in a safe environment.


### PR DESCRIPTION
## Summary
- add README files to mockjira, mcp_jira, and the Python client describing how each piece supports Codex-style workflows
- extend AGENTS.md with links to the new docs and an explicit MCP-to-Jira connection checklist

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce74437d1c8330b1574bdd79e8692a